### PR TITLE
hotfix: migrar @koalarx/utils para 5.0 (v22.2.1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@koalarx/ui",
       "dependencies": {
-        "@koalarx/utils": "^4.2.5",
+        "@koalarx/utils": "^5.0.0",
         "chalk": "4.1.2",
         "clsx": "^2.1.1",
         "prompts": "^2.4.2",
@@ -126,7 +126,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@koalarx/utils": ["@koalarx/utils@4.2.5", "", { "dependencies": { "date-fns": "^4.4.0", "date-holidays": "^3.30.2", "validation-br": "^1.6.4" } }, "sha512-4AO2kSWAzhscSvdgelMCOTkNIDBw6NA2sr3FVeFXKGflyztXc+PAHne1MtiBrG0cAmGAZYjF+EQdcroLxljFRw=="],
+    "@koalarx/utils": ["@koalarx/utils@5.0.0", "", { "dependencies": { "date-fns": "^4.4.0", "validation-br": "^1.6.4" }, "peerDependencies": { "date-holidays": "^3.32.0" }, "optionalPeers": ["date-holidays"] }, "sha512-7Mq50T+G7Ck+sst+xdfeCkODBRsn0OQiP9pgBLsb1vCm4rh5ZjyaGH1LrsX38qle5qwsEnyF7C/nAG5vt7keLw=="],
 
     "@pkgr/core": ["@pkgr/core@0.3.6", "", {}, "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA=="],
 
@@ -246,15 +246,11 @@
 
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
 
-    "astronomia": ["astronomia@4.2.0", "", {}, "sha512-mTvpBGyXB80aSsDhAAiuwza5VqAyqmj5yzhjBrFhRy17DcWDzJrb8Vdl4Sm+g276S+mY7bk/5hi6akZ5RQFeHg=="],
-
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
-    "caldate": ["caldate@2.0.5", "", { "dependencies": { "moment-timezone": "^0.5.43" } }, "sha512-JndhrUuDuE975KUhFqJaVR1OQkCHZqpOrJur/CFXEIEhWhBMjxO85cRSK8q4FW+B+yyPq6GYua2u4KvNzTcq0w=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -272,23 +268,11 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "date-bengali-revised": ["date-bengali-revised@2.0.2", "", {}, "sha512-q9iDru4+TSA9k4zfm0CFHJj6nBsxP7AYgWC/qodK/i7oOIlj5K2z5IcQDtESfs/Qwqt/xJYaP86tkazd/vRptg=="],
-
-    "date-chinese": ["date-chinese@2.1.4", "", { "dependencies": { "astronomia": "^4.1.0" } }, "sha512-WY+6+Qw92ZGWFvGtStmNQHEYpNa87b8IAQ5T8VKt4wqrn24lBXyyBnWI5jAIyy7h/KVwJZ06bD8l/b7yss82Ww=="],
-
-    "date-easter": ["date-easter@1.0.3", "", {}, "sha512-aOViyIgpM4W0OWUiLqivznwTtuMlD/rdUWhc5IatYnplhPiWrLv75cnifaKYhmQwUBLAMWLNG4/9mlLIbXoGBQ=="],
-
     "date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
-
-    "date-holidays": ["date-holidays@3.30.2", "", { "dependencies": { "date-holidays-parser": "^3.4.7", "js-yaml": "^4.1.1", "lodash": "^4.18.1", "prepin": "^1.0.3" }, "bin": { "holidays2json": "scripts/holidays2json.cjs" } }, "sha512-B7GLBc/7ucEw4KZeRKRMZin1NlTbQJtXn4tW4lHoRKdRzB68A/O6s/Jxlr/zStkZv43IeAQivYii/0dJytikGw=="],
-
-    "date-holidays-parser": ["date-holidays-parser@3.4.7", "", { "dependencies": { "astronomia": "^4.1.1", "caldate": "^2.0.5", "date-bengali-revised": "^2.0.2", "date-chinese": "^2.1.4", "date-easter": "^1.0.3", "deepmerge": "^4.3.1", "jalaali-js": "^1.2.7", "moment-timezone": "^0.5.47" } }, "sha512-h09ZEtM6u5cYM6m1bX+1Ny9f+nLO9KVZUKNPEnH7lhbXYTfqZogaGTnhONswGeIJFF91UImIftS3CdM9HLW5oQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
-
-    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
@@ -368,8 +352,6 @@
 
     "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
 
-    "jalaali-js": ["jalaali-js@1.2.8", "", {}, "sha512-Jl/EwY84JwjW2wsWqeU4pNd22VNQ7EkjI36bDuLw31wH98WQW4fPjD0+mG7cdCK+Y8D6s9R3zLiQ3LaKu6bD8A=="],
-
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
@@ -388,8 +370,6 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
-
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -399,10 +379,6 @@
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
-    "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
-
-    "moment-timezone": ["moment-timezone@0.5.48", "", { "dependencies": { "moment": "^2.29.4" } }, "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -433,8 +409,6 @@
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
-
-    "prepin": ["prepin@1.0.3", "", { "bin": { "prepin": "./bin/prepin.js" } }, "sha512-0XL2hreherEEvUy0fiaGEfN/ioXFV+JpImqIzQjxk6iBg4jQ2ARKqvC4+BmRD8w/pnpD+lbxvh0Ub+z7yBEjvA=="],
 
     "prettier": ["prettier@3.7.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA=="],
 

--- a/libs/ui/public/docs/combobox.md
+++ b/libs/ui/public/docs/combobox.md
@@ -109,11 +109,13 @@ export class ComboboxRemoteSample {
           ]).split(30)[0],
         ).orderBy('firstName', 'asc');
 
-        return users.map((user) => ({
-          value: user.id,
-          label: `${user.firstName} ${user.lastName}`,
-          data: user,
-        }));
+        return [
+          ...users.map((user) => ({
+            value: user.id,
+            label: `${user.firstName} ${user.lastName}`,
+            data: user,
+          })),
+        ];
       },
     });
 }

--- a/libs/ui/public/docs/inline-filter.md
+++ b/libs/ui/public/docs/inline-filter.md
@@ -65,11 +65,13 @@ export class InlineFilterSample {
             .orderBy('firstName', 'asc')
             .split(30)[0] ?? [];
 
-        return users.map((user) => ({
-          value: user.id,
-          label: `${user.firstName} ${user.lastName}`,
-          data: user,
-        }));
+        return [
+          ...users.map((user) => ({
+            value: user.id,
+            label: `${user.firstName} ${user.lastName}`,
+            data: user,
+          })),
+        ];
       },
     });
 

--- a/libs/ui/public/llms-full.txt
+++ b/libs/ui/public/llms-full.txt
@@ -690,11 +690,13 @@ export class ComboboxRemoteSample {
           ]).split(30)[0],
         ).orderBy('firstName', 'asc');
 
-        return users.map((user) => ({
-          value: user.id,
-          label: `${user.firstName} ${user.lastName}`,
-          data: user,
-        }));
+        return [
+          ...users.map((user) => ({
+            value: user.id,
+            label: `${user.firstName} ${user.lastName}`,
+            data: user,
+          })),
+        ];
       },
     });
 }
@@ -1230,11 +1232,13 @@ export class InlineFilterSample {
             .orderBy('firstName', 'asc')
             .split(30)[0] ?? [];
 
-        return users.map((user) => ({
-          value: user.id,
-          label: `${user.firstName} ${user.lastName}`,
-          data: user,
-        }));
+        return [
+          ...users.map((user) => ({
+            value: user.id,
+            label: `${user.firstName} ${user.lastName}`,
+            data: user,
+          })),
+        ];
       },
     });
 

--- a/libs/ui/public/markdown/usage/combobox/combobox-remote.ts.md
+++ b/libs/ui/public/markdown/usage/combobox/combobox-remote.ts.md
@@ -46,11 +46,13 @@ export class ComboboxRemoteSample {
           ]).split(30)[0],
         ).orderBy('firstName', 'asc');
 
-        return users.map((user) => ({
-          value: user.id,
-          label: `${user.firstName} ${user.lastName}`,
-          data: user,
-        }));
+        return [
+          ...users.map((user) => ({
+            value: user.id,
+            label: `${user.firstName} ${user.lastName}`,
+            data: user,
+          })),
+        ];
       },
     });
 }

--- a/libs/ui/public/markdown/usage/inline-filter/inline-filter.ts.md
+++ b/libs/ui/public/markdown/usage/inline-filter/inline-filter.ts.md
@@ -51,11 +51,13 @@ export class InlineFilterSample {
             .orderBy('firstName', 'asc')
             .split(30)[0] ?? [];
 
-        return users.map((user) => ({
-          value: user.id,
-          label: `${user.firstName} ${user.lastName}`,
-          data: user,
-        }));
+        return [
+          ...users.map((user) => ({
+            value: user.id,
+            label: `${user.firstName} ${user.lastName}`,
+            data: user,
+          })),
+        ];
       },
     });
 

--- a/libs/ui/src/app/core/components/footer/footer.html
+++ b/libs/ui/src/app/core/components/footer/footer.html
@@ -41,7 +41,7 @@
         </li>
         <li>
           <a
-            href="https://www.npmjs.com/package/@koalarx/utils"
+            href="https://utils.koalarx.com/"
             target="_blank"
             rel="noopener noreferrer"
             class="inline-flex items-center gap-1.5 transition-opacity hover:opacity-100"

--- a/libs/ui/src/app/core/components/section/section-container.ts
+++ b/libs/ui/src/app/core/components/section/section-container.ts
@@ -12,7 +12,7 @@ import {
   signal,
 } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
-import { delay } from '@koalarx/utils/light';
+import { delay } from '@koalarx/utils/KlDelay';
 
 @Component({
   selector: 'app-section-container',

--- a/libs/ui/src/app/core/constants/app-version.ts
+++ b/libs/ui/src/app/core/constants/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '22.2.0';
+export const APP_VERSION = '22.2.1';

--- a/libs/ui/src/app/features/components/combobox/combobox.page.ts
+++ b/libs/ui/src/app/features/components/combobox/combobox.page.ts
@@ -82,11 +82,13 @@ export class ComboboxPage {
           ]).split(30)[0],
         ).orderBy('firstName', 'asc');
 
-        return users.map((user) => ({
-          value: user.id,
-          label: `${user.firstName} ${user.lastName}`,
-          data: user,
-        }));
+        return [
+          ...users.map((user) => ({
+            value: user.id,
+            label: `${user.firstName} ${user.lastName}`,
+            data: user,
+          })),
+        ];
       },
     });
 }

--- a/libs/ui/src/app/features/components/inline-filter/inline-filter.page.ts
+++ b/libs/ui/src/app/features/components/inline-filter/inline-filter.page.ts
@@ -53,11 +53,13 @@ export class InlineFilterPage {
             .orderBy('firstName', 'asc')
             .split(30)[0] ?? [];
 
-        return users.map((user) => ({
-          value: user.id,
-          label: `${user.firstName} ${user.lastName}`,
-          data: user,
-        }));
+        return [
+          ...users.map((user) => ({
+            value: user.id,
+            label: `${user.firstName} ${user.lastName}`,
+            data: user,
+          })),
+        ];
       },
     });
 

--- a/libs/ui/src/app/features/components/inline-filter/inline-filter.sample.ts
+++ b/libs/ui/src/app/features/components/inline-filter/inline-filter.sample.ts
@@ -51,11 +51,13 @@ export class InlineFilterSample {
             .orderBy('firstName', 'asc')
             .split(30)[0] ?? [];
 
-        return users.map((user) => ({
-          value: user.id,
-          label: `${user.firstName} ${user.lastName}`,
-          data: user,
-        }));
+        return [
+          ...users.map((user) => ({
+            value: user.id,
+            label: `${user.firstName} ${user.lastName}`,
+            data: user,
+          })),
+        ];
       },
     });
 

--- a/libs/ui/src/app/shared/components/calendar/calendar.ts
+++ b/libs/ui/src/app/shared/components/calendar/calendar.ts
@@ -8,7 +8,7 @@ import {
   output,
   viewChild,
 } from '@angular/core';
-import { KlDate } from '@koalarx/utils/light/KlDate';
+import { KlDate } from '@koalarx/utils/KlDate';
 import 'cally';
 import { setupCalendarChangeEffect } from './effects/setup-calendar-change.effect';
 

--- a/libs/ui/src/app/shared/components/calendar/effects/setup-calendar-change.effect.ts
+++ b/libs/ui/src/app/shared/components/calendar/effects/setup-calendar-change.effect.ts
@@ -1,5 +1,5 @@
 import { effect, ElementRef } from '@angular/core';
-import { KlDate } from '@koalarx/utils/light/KlDate';
+import { KlDate } from '@koalarx/utils/KlDate';
 import type { CalendarType } from '..';
 
 interface SetupCalendarChangeEffectParams {

--- a/libs/ui/src/app/shared/components/calendar/input-calendar.helpers.ts
+++ b/libs/ui/src/app/shared/components/calendar/input-calendar.helpers.ts
@@ -1,4 +1,4 @@
-import { KlDate } from '@koalarx/utils/light/KlDate';
+import { KlDate } from '@koalarx/utils/KlDate';
 import { InputCalendarFormat, InputCalendarType } from '.';
 
 export interface CalendarMonthValue {

--- a/libs/ui/src/app/shared/components/calendar/input-calendar.ts
+++ b/libs/ui/src/app/shared/components/calendar/input-calendar.ts
@@ -10,7 +10,7 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
-import { KlDate } from '@koalarx/utils/light/KlDate';
+import { KlDate } from '@koalarx/utils/KlDate';
 import 'cally';
 import { Calendar } from '.';
 import { Mask } from '../../directives/mask.directive';

--- a/libs/ui/src/app/shared/components/inline-filter/parts/fields/calendar/inline-filter-calendar.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/fields/calendar/inline-filter-calendar.ts
@@ -1,7 +1,7 @@
 import { InputCalendar } from '@/shared/components/calendar';
 import { Component, effect, OnInit, viewChild } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { KlDate } from '@koalarx/utils/light/KlDate';
+import { KlDate } from '@koalarx/utils/KlDate';
 import { FieldBase } from '../field.base';
 
 @Component({

--- a/libs/ui/src/app/shared/components/inline-filter/utils/query-params-to-options/to-calendar.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/utils/query-params-to-options/to-calendar.ts
@@ -1,4 +1,4 @@
-import { KlDate } from '@koalarx/utils/light/KlDate';
+import { KlDate } from '@koalarx/utils/KlDate';
 import { InlineFilterField } from '../../config';
 
 export function toCalendar(option: InlineFilterField, value: string) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "packageManager": "bun@1.3.6",
   "dependencies": {
-    "@koalarx/utils": "^4.2.5",
+    "@koalarx/utils": "^5.0.0",
     "chalk": "4.1.2",
     "clsx": "^2.1.1",
     "prompts": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/ui",
-  "version": "22.2.0",
+  "version": "22.2.1",
   "scripts": {
     "build": "bun scripts/build",
     "build:doc": "bun run build:docs",


### PR DESCRIPTION
## Summary
- Migra `@koalarx/utils` de 4.x para 5.0 (remove imports `/light`, usa `KlDate`/`KlDelay`)
- Ajusta samples onde `KlArray.map` passa a retornar `KlArray`
- Atualiza o link do footer para a doc oficial https://utils.koalarx.com/
- Bump de versão para **22.2.1**

## Test plan
- [ ] `bun run test:cli`
- [ ] Build da UI (`ng build`) com os novos subpaths
- [ ] Conferir link `@koalarx/utils` no footer


Made with [Cursor](https://cursor.com)