### PR TITLE
hotfix(cli): flag --silent para install/new/init (22.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ O conteúdo principal da página web vive em `libs/ui/src/app/core/i18n/docs/pag
 
 Formato inspirado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/).
 
+## [22.3.1] — CLI `--silent`
+
+### Added
+
+- Flag `--silent` em `kl new`, `kl init` e `kl install` para modo não interativo (aceita libs externas sem prompt; no `new`/`init` defaults `bun` + AI context `none`).
+
+Detalhes: [Patch notes — 22.3.1](https://ui.koalarx.com/#/getting-started/patch-notes).
+
 ## [22.3.0] — Contexto AI
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ During project creation, the CLI asks which package manager you want to use and 
 - `yarn`
 - `pnpm`
 
-You can also skip the interactive prompts with `--pm` and `--ai-context`.
+You can also skip the interactive prompts with `--pm`, `--ai-context`, and `--silent` (non-interactive defaults: bun + AI context none).
 
 ```bash
 kl new --name meu-projeto
 kl new --name my-project --pm npm
 kl new my-app --ai-context both
+kl new my-app --silent
 ```
 
 ---
@@ -52,10 +53,13 @@ kl new my-app --ai-context both
 
 Adds one or more UI components to the project.
 
+Use `--silent` to accept all external dependency installs without prompting (recommended for AI agents and CI).
+
 ```bash
 kl install button
 kl install button,loading,dropdown
 kl install modal --project meu-projeto
+kl install button,modal --silent
 ```
 
 ---
@@ -81,6 +85,7 @@ kl init
 kl init --project meu-projeto
 kl init --project meu-projeto --verbose
 kl init --ai-context none
+kl init --silent
 ```
 
 ---

--- a/libs/cli/assets/ai-context/.cursor/rules/koala-components.mdc
+++ b/libs/cli/assets/ai-context/.cursor/rules/koala-components.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # Componentes
 
-- Instale o que faltar: `kl install button,modal,dropdown` (vírgulas; a CLI resolve dependências).
+- Instale o que faltar: `kl install button,modal,dropdown --silent` (vírgulas; `--silent` aceita libs externas sem prompt).
 - Destino padrão: `src/app/shared/components/<name>/`.
 - Importe em standalone `imports` a partir de `@/shared/components/...` (ou o caminho já usado no repo).
 - Não invente inputs/outputs/diretivas — leia a doc do componente (`https://ui.koalarx.com/docs/<slug>.md`, ou `/v{major}/docs/<slug>.md` na linha previous) ou o MCP `koala-ui-docs`.

--- a/libs/cli/assets/ai-context/.github/copilot-instructions.md
+++ b/libs/cli/assets/ai-context/.github/copilot-instructions.md
@@ -14,8 +14,8 @@ Useful entry points: [Get Started](https://ui.koalarx.com/docs/get-started.md), 
 
 ## Hard constraints
 
-- Install missing pieces with `kl install <component[,component]>`. Components land under `src/app/shared/components/`.
-- Prefer Signals, standalone components, and path aliases (`@/*` → `src/app/*`) from `kl new` / `kl init`.
+- Install missing pieces with `kl install <component[,component]> --silent`. Components land under `src/app/shared/components/`. Always pass `--silent` so external dependency prompts do not block the agent.
+- Prefer Signals, standalone components, and path aliases (`@/*` → `src/app/*`) from `kl new` / `kl init`. For non-interactive scaffolding use `kl new <name> --silent` (or `--pm` / `--ai-context`).
 - Base deps: `@koalarx/utils` ≥ 5 and `clsx`. Prefer documented Utils prototypes (e.g. `.orderBy()`).
 - Import installed UI from `@/shared/components/...` (or the local path already used in this repo). Follow existing `imports` arrays on standalone components.
 - Do not invent undocumented directives, inputs, or APIs — match docs and the sources already in this tree.
@@ -23,7 +23,7 @@ Useful entry points: [Get Started](https://ui.koalarx.com/docs/get-started.md), 
 ## New UI recipe
 
 1. Check whether the component/resource already exists under `src/app/shared/`.
-2. If missing: `kl install button,modal` (or the needed names); resolve transitive deps the CLI installs.
+2. If missing: `kl install button,modal --silent` (or the needed names); `--silent` accepts all external libs without prompting.
 3. Read the docs page for each piece before wiring templates.
 4. Compose with documented patterns (fieldset + inputs, toast feedback, modal/side-window, etc.).
 5. Keep styles aligned with the project theme (Tailwind / DaisyUI setup from scaffolding).

--- a/libs/cli/assets/ai-context/AGENTS.md
+++ b/libs/cli/assets/ai-context/AGENTS.md
@@ -14,8 +14,8 @@ Useful entry points: [Get Started](https://ui.koalarx.com/docs/get-started.md), 
 
 ## Hard constraints
 
-- Install missing pieces with `kl install <component[,component]>`. Components land under `src/app/shared/components/`.
-- Prefer Signals, standalone components, and path aliases (`@/*` → `src/app/*`) from `kl new` / `kl init`.
+- Install missing pieces with `kl install <component[,component]> --silent`. Components land under `src/app/shared/components/`. Always pass `--silent` so external dependency prompts do not block the agent.
+- Prefer Signals, standalone components, and path aliases (`@/*` → `src/app/*`) from `kl new` / `kl init`. For non-interactive scaffolding use `kl new <name> --silent` (or `--pm` / `--ai-context`).
 - Base deps: `@koalarx/utils` ≥ 5 and `clsx`. Prefer documented Utils prototypes (e.g. `.orderBy()`).
 - Import installed UI from `@/shared/components/...` (or the local path already used in this repo). Follow existing `imports` arrays on standalone components.
 - Do not invent undocumented directives, inputs, or APIs — match docs and the sources already in this tree.
@@ -23,7 +23,7 @@ Useful entry points: [Get Started](https://ui.koalarx.com/docs/get-started.md), 
 ## New UI recipe
 
 1. Check whether the component/resource already exists under `src/app/shared/`.
-2. If missing: `kl install button,modal` (or the needed names); resolve transitive deps the CLI installs.
+2. If missing: `kl install button,modal --silent` (or the needed names); `--silent` accepts all external libs without prompting.
 3. Read the docs page for each piece before wiring templates.
 4. Compose with documented patterns (fieldset + inputs, toast feedback, modal/side-window, etc.).
 5. Keep styles aligned with the project theme (Tailwind / DaisyUI setup from scaffolding).

--- a/libs/cli/commands/init.ts
+++ b/libs/cli/commands/init.ts
@@ -5,14 +5,18 @@ export interface InitArgs {
   project?: string;
   verbose?: boolean;
   aiContext?: string;
+  /** Skip interactive prompts (AI context defaults to none unless --ai-context is set). */
+  silent?: boolean;
 }
 
 export async function runInitCommand(args: InitArgs): Promise<void> {
   const logger = console.log;
   const projectName = args.project || (process.cwd().split('/').pop() as string);
   const verbose = args.verbose ?? false;
+  const silent = args.silent ?? false;
+  const aiContext = args.aiContext ?? (silent ? 'none' : undefined);
 
   logHeader(logger, 'KOALA PROJECT INITIALIZER', `Project: ${projectName}`);
 
-  await setupExistingProject(projectName, verbose, args.aiContext);
+  await setupExistingProject(projectName, verbose, aiContext);
 }

--- a/libs/cli/commands/init.unit.spec.ts
+++ b/libs/cli/commands/init.unit.spec.ts
@@ -66,6 +66,22 @@ describe('Init Command', () => {
     );
   });
 
+  it('should default aiContext to none when silent is set without aiContext', async () => {
+    const { setupExistingProject } = await import('../utils/setup-existing-project');
+
+    await runInitCommand({ project: 'test-project', silent: true });
+
+    expect(vi.mocked(setupExistingProject)).toHaveBeenCalledWith('test-project', false, 'none');
+  });
+
+  it('should keep explicit aiContext when silent is set', async () => {
+    const { setupExistingProject } = await import('../utils/setup-existing-project');
+
+    await runInitCommand({ project: 'test-project', silent: true, aiContext: 'both' });
+
+    expect(vi.mocked(setupExistingProject)).toHaveBeenCalledWith('test-project', false, 'both');
+  });
+
   it('should call logHeader with correct parameters', async () => {
     const { logHeader } = await import('../utils/cli-ui');
 

--- a/libs/cli/commands/install.ts
+++ b/libs/cli/commands/install.ts
@@ -9,12 +9,14 @@ export interface InstallArgs {
   name: string;
   project?: string;
   verbose?: boolean;
+  silent?: boolean;
 }
 
 export async function runInstallCommand(args: InstallArgs): Promise<void> {
   const logger = console.log;
   const projectName = args.project || (process.cwd().split('/').pop() as string);
   const verbose = args.verbose ?? false;
+  const silent = args.silent ?? false;
 
   if (!args.name) {
     throw new Error('Please provide components (e.g. "kl install button") or use --name/-n');
@@ -34,7 +36,7 @@ export async function runInstallCommand(args: InstallArgs): Promise<void> {
   );
 
   for (const componentName of flagOptions) {
-    const result = await install(projectName, componentName, verbose);
+    const result = await install(projectName, componentName, verbose, silent);
 
     if (result.missingLibs.length > 0) {
       logWarning(

--- a/libs/cli/commands/new.ts
+++ b/libs/cli/commands/new.ts
@@ -22,6 +22,8 @@ export interface NewArgs {
   pm?: PackageManager;
   verbose?: boolean;
   aiContext?: string;
+  /** Accept defaults without prompts (package manager + AI context). */
+  silent?: boolean;
 }
 
 async function createAngularProject(
@@ -134,12 +136,13 @@ function createFolderStructure(name: string) {
 export async function runNewCommand(args: NewArgs): Promise<void> {
   const name = args.name;
   const verbose = args.verbose ?? false;
+  const silent = args.silent ?? false;
 
   if (!name) {
     throw new Error('Please provide a project name (e.g. "kl new example") or use --name/-n');
   }
 
-  const pmName = args.pm ?? (await askPackageManager());
+  const pmName = args.pm ?? (silent ? 'bun' : await askPackageManager());
   const pm = getPmCommands(pmName);
 
   logHeader(console.log, 'KOALA UI PROJECT SETUP', `Project: ${name}`);
@@ -172,7 +175,8 @@ export async function runNewCommand(args: NewArgs): Promise<void> {
   installUtil(name, 'control-changes');
   installUtil(name, 'form-is-valid');
 
-  const aiContextTargets = await resolveAiContextTargets(args.aiContext);
+  const aiContextFlag = args.aiContext ?? (silent ? 'none' : undefined);
+  const aiContextTargets = await resolveAiContextTargets(aiContextFlag);
   applyAiContext(name, aiContextTargets);
 
   logSuccess(console.log, 'Project ready');

--- a/libs/cli/runner.ts
+++ b/libs/cli/runner.ts
@@ -83,12 +83,12 @@ function printHelp() {
   printBanner();
   console.log('Usage:');
   console.log(
-    '  kl new <project> [--pm bun|npm|yarn|pnpm] [--ai-context none|cursor|github|both] [--verbose]',
+    '  kl new <project> [--pm bun|npm|yarn|pnpm] [--ai-context none|cursor|github|both] [--silent] [--verbose]',
   );
   console.log(
-    '  kl init [--project <name>] [--ai-context none|cursor|github|both] [--verbose]',
+    '  kl init [--project <name>] [--ai-context none|cursor|github|both] [--silent] [--verbose]',
   );
-  console.log('  kl install <component[,component]> [--project <name>] [--verbose]');
+  console.log('  kl install <component[,component]> [--project <name>] [--silent] [--verbose]');
   console.log('  kl add ai-context cursor|github [--project <name>]');
   console.log('  kl version');
   console.log('');
@@ -104,14 +104,17 @@ function printInstallHelp() {
   console.log('add a component to the project');
   console.log('');
   console.log('USAGE');
-  console.log('  $ kl install <value> [-p <value>] [--verbose]');
-  console.log('  $ kl install -n <value> [-p <value>] [--verbose]');
+  console.log('  $ kl install <value> [-p <value>] [--silent] [--verbose]');
+  console.log('  $ kl install -n <value> [-p <value>] [--silent] [--verbose]');
   console.log('');
   console.log('FLAGS');
   console.log(
     '  -n, --name=<value>     list of components to install. Separate multiple components with a comma',
   );
   console.log('  -p, --project=<value>  name of the project');
+  console.log(
+    '      --silent           accept all external dependency installs without prompting',
+  );
   console.log('  -v, --verbose          show detailed install logs');
 }
 
@@ -120,12 +123,15 @@ function printInitHelp() {
   console.log('');
   console.log('USAGE');
   console.log('  $ kl init');
-  console.log('  $ kl init [-p <value>] [--ai-context <value>] [--verbose]');
+  console.log('  $ kl init [-p <value>] [--ai-context <value>] [--silent] [--verbose]');
   console.log('');
   console.log('FLAGS');
   console.log('  -p, --project=<value>  name of the project (defaults to current directory)');
   console.log(
     '      --ai-context=<value>  none|cursor|github|both (skips interactive prompt)',
+  );
+  console.log(
+    '      --silent           non-interactive: skip prompts (AI context defaults to none)',
   );
   console.log('  -v, --verbose          show detailed logs');
   console.log('');
@@ -158,10 +164,22 @@ function printAddHelp() {
 }
 
 function printNewHelp() {
-  console.log('Usage: kl new <project> [--pm bun|npm|yarn|pnpm] [--ai-context none|cursor|github|both] [--verbose]');
   console.log(
-    '       kl new --name <project> [--pm bun|npm|yarn|pnpm] [--ai-context none|cursor|github|both] [--verbose]',
+    'Usage: kl new <project> [--pm bun|npm|yarn|pnpm] [--ai-context none|cursor|github|both] [--silent] [--verbose]',
   );
+  console.log(
+    '       kl new --name <project> [--pm bun|npm|yarn|pnpm] [--ai-context none|cursor|github|both] [--silent] [--verbose]',
+  );
+  console.log('');
+  console.log('FLAGS');
+  console.log('  -m, --pm=<value>         package manager: bun|npm|yarn|pnpm');
+  console.log(
+    '      --ai-context=<value>  none|cursor|github|both (skips interactive prompt)',
+  );
+  console.log(
+    '      --silent              non-interactive: bun + AI context none unless overridden',
+  );
+  console.log('  -v, --verbose            show detailed logs');
 }
 
 export async function runCli(argv: string[]): Promise<number> {
@@ -187,8 +205,9 @@ export async function runCli(argv: string[]): Promise<number> {
       const name = getFirstPositionalArg(args) ?? getFlagValue(args, 'name', 'n');
       const pm = getFlagValue(args, 'pm', 'm') as PackageManager | undefined;
       const verbose = hasFlag(args, 'verbose', 'v');
+      const silent = hasFlag(args, 'silent');
       const aiContext = getFlagValue(args, 'ai-context');
-      await runNewCommand({ name: name ?? '', pm, verbose, aiContext });
+      await runNewCommand({ name: name ?? '', pm, verbose, aiContext, silent });
       return 0;
     }
 
@@ -200,8 +219,9 @@ export async function runCli(argv: string[]): Promise<number> {
 
       const project = getFlagValue(args, 'project', 'p');
       const verbose = hasFlag(args, 'verbose', 'v');
+      const silent = hasFlag(args, 'silent');
       const aiContext = getFlagValue(args, 'ai-context');
-      await runInitCommand({ project, verbose, aiContext });
+      await runInitCommand({ project, verbose, aiContext, silent });
       return 0;
     }
 
@@ -214,7 +234,8 @@ export async function runCli(argv: string[]): Promise<number> {
       const name = getFirstPositionalArg(args) ?? getFlagValue(args, 'name', 'n');
       const project = getFlagValue(args, 'project', 'p');
       const verbose = hasFlag(args, 'verbose', 'v');
-      await runInstallCommand({ name: name ?? '', project, verbose });
+      const silent = hasFlag(args, 'silent');
+      await runInstallCommand({ name: name ?? '', project, verbose, silent });
       return 0;
     }
 

--- a/libs/cli/runner.unit.spec.ts
+++ b/libs/cli/runner.unit.spec.ts
@@ -19,6 +19,7 @@ import { runCli } from './runner';
 import { runAddCommand } from './commands/add';
 import { runNewCommand } from './commands/new';
 import { runInitCommand } from './commands/init';
+import { runInstallCommand } from './commands/install';
 
 describe('CLI Runner', () => {
   beforeEach(() => {
@@ -66,6 +67,20 @@ describe('CLI Runner', () => {
       pm: undefined,
       verbose: false,
       aiContext: 'none',
+      silent: false,
+    });
+  });
+
+  it('should pass --silent to new', async () => {
+    const result = await runCli(['new', 'demo', '--silent']);
+
+    expect(result).toBe(0);
+    expect(runNewCommand).toHaveBeenCalledWith({
+      name: 'demo',
+      pm: undefined,
+      verbose: false,
+      aiContext: undefined,
+      silent: true,
     });
   });
 
@@ -77,6 +92,19 @@ describe('CLI Runner', () => {
       project: undefined,
       verbose: false,
       aiContext: 'cursor',
+      silent: false,
+    });
+  });
+
+  it('should pass --silent to install', async () => {
+    const result = await runCli(['install', 'button', '--silent']);
+
+    expect(result).toBe(0);
+    expect(runInstallCommand).toHaveBeenCalledWith({
+      name: 'button',
+      project: undefined,
+      verbose: false,
+      silent: true,
     });
   });
 });

--- a/libs/cli/utils/install-lib.ts
+++ b/libs/cli/utils/install-lib.ts
@@ -9,26 +9,29 @@ export async function installLib(
   projectName: string,
   lib: string,
   verbose = false,
+  silent = false,
 ): Promise<boolean> {
-  const response = await prompts(
-    {
-      type: 'toggle',
-      name: 'confirm',
-      message: `${chalk.cyan('KoalaUI')} Install dependency ${chalk.yellow(lib)} now?`,
-      hint: 'Required by selected component',
-      initial: true,
-      active: 'Yes',
-      inactive: 'No',
-    },
-    {
-      onCancel: () => {
-        throw new Error('KoalaUI: dependency installation prompt was cancelled.');
+  if (!silent) {
+    const response = await prompts(
+      {
+        type: 'toggle',
+        name: 'confirm',
+        message: `${chalk.cyan('KoalaUI')} Install dependency ${chalk.yellow(lib)} now?`,
+        hint: 'Required by selected component',
+        initial: true,
+        active: 'Yes',
+        inactive: 'No',
       },
-    },
-  );
+      {
+        onCancel: () => {
+          throw new Error('KoalaUI: dependency installation prompt was cancelled.');
+        },
+      },
+    );
 
-  if (!response.confirm) {
-    return false;
+    if (!response.confirm) {
+      return false;
+    }
   }
 
   const pm = detectPackageManager(projectName);

--- a/libs/cli/utils/install-lib.unit.spec.ts
+++ b/libs/cli/utils/install-lib.unit.spec.ts
@@ -47,4 +47,16 @@ describe('installLib', () => {
     expect(result).toBe(false);
     expect(runCommand).not.toHaveBeenCalled();
   });
+
+  it('should install lib without prompting when silent is true', async () => {
+    const result = await installLib('my-app', '@angular/aria', false, true);
+
+    expect(result).toBe(true);
+    expect(prompts).not.toHaveBeenCalled();
+    expect(runCommand).toHaveBeenCalledWith('bun add @angular/aria@^21.2.10', {
+      cwd: '/tmp/project',
+      loaderText: 'Installing @angular/aria',
+      verbose: false,
+    });
+  });
 });

--- a/libs/cli/utils/install.ts
+++ b/libs/cli/utils/install.ts
@@ -15,6 +15,7 @@ export async function install(
   projectName: string,
   component: InstallComponentFlags,
   verbose = false,
+  silent = false,
 ): Promise<InstallResult> {
   const installedComponentDeps: InstallComponentFlags[] = [];
   const installedLibDeps: string[] = [];
@@ -30,7 +31,7 @@ export async function install(
   const deps = installComponent(projectName, component);
 
   for (const dep of getNotInstalled(projectName, 'lib', deps.libDeps)) {
-    const installed = await installLib(projectName, dep, verbose);
+    const installed = await installLib(projectName, dep, verbose, silent);
 
     if (installed) {
       installedLibDeps.push(dep);
@@ -75,7 +76,7 @@ export async function install(
   }
 
   for (const component of getNotInstalled(projectName, 'component', deps.componentDeps)) {
-    const result = await install(projectName, component, verbose);
+    const result = await install(projectName, component, verbose, silent);
     installedComponentDeps.push(...result.components, component);
     installedLibDeps.push(...result.libs);
     installedUtilDeps.push(...result.utils);

--- a/libs/ui/public/docs/get-started.md
+++ b/libs/ui/public/docs/get-started.md
@@ -39,9 +39,16 @@ kl new example --ai-context none
 
 # scaffold Cursor + Copilot context without prompting
 kl new example --ai-context both
+
+# non-interactive (AI agents / CI): bun + AI context none
+kl new example --silent
+
+# non-interactive with overrides
+kl new example --silent --pm pnpm --ai-context both
 ```
 
 During setup you can scaffold AI context (Cursor / GitHub Copilot). Use `--ai-context none|cursor|github|both` to skip the prompt.
+For AI agents or CI, prefer `--silent` (non-interactive: bun + AI context none unless overridden).
 
 ## 3. Add components
 
@@ -50,7 +57,12 @@ kl install button,dropdown,modal
 
 # target a specific project
 kl install modal --project my-angular-app
+
+# accept all external dependency installs without prompting (AI agents / CI)
+kl install button,modal --silent
 ```
+
+Use `kl install … --silent` to accept all external dependency installs without prompting (recommended for AI agents).
 
 ## 4. Add AI context (optional)
 

--- a/libs/ui/public/docs/patch-notes.md
+++ b/libs/ui/public/docs/patch-notes.md
@@ -4,6 +4,16 @@ Changelog for anyone using or upgrading projects scaffolded with the Koala UI CL
 Site page: https://ui.koalarx.com/#/getting-started/patch-notes
 Root CHANGELOG.md mirrors these notes.
 
+## 22.3.1 — CLI --silent
+
+### What changed
+
+- `--silent` flag on `kl new`, `kl init`, and `kl install`: non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none).
+
+### Upgrade
+
+For AI agents or CI, prefer `kl install … --silent` and `kl new … --silent`. Interactive use without the flag is unchanged.
+
 ## 22.3.0 — AI context
 
 ### What changed

--- a/libs/ui/public/llms-full.txt
+++ b/libs/ui/public/llms-full.txt
@@ -41,9 +41,16 @@ kl new example --ai-context none
 
 # scaffold Cursor + Copilot context without prompting
 kl new example --ai-context both
+
+# non-interactive (AI agents / CI): bun + AI context none
+kl new example --silent
+
+# non-interactive with overrides
+kl new example --silent --pm pnpm --ai-context both
 ```
 
 During setup you can scaffold AI context (Cursor / GitHub Copilot). Use `--ai-context none|cursor|github|both` to skip the prompt.
+For AI agents or CI, prefer `--silent` (non-interactive: bun + AI context none unless overridden).
 
 ## 3. Add components
 
@@ -52,7 +59,12 @@ kl install button,dropdown,modal
 
 # target a specific project
 kl install modal --project my-angular-app
+
+# accept all external dependency installs without prompting (AI agents / CI)
+kl install button,modal --silent
 ```
+
+Use `kl install … --silent` to accept all external dependency installs without prompting (recommended for AI agents).
 
 ## 4. Add AI context (optional)
 
@@ -123,6 +135,16 @@ kl add ai-context cursor github
 Changelog for anyone using or upgrading projects scaffolded with the Koala UI CLI.
 Site page: https://ui.koalarx.com/#/getting-started/patch-notes
 Root CHANGELOG.md mirrors these notes.
+
+## 22.3.1 — CLI --silent
+
+### What changed
+
+- `--silent` flag on `kl new`, `kl init`, and `kl install`: non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none).
+
+### Upgrade
+
+For AI agents or CI, prefer `kl install … --silent` and `kl new … --silent`. Interactive use without the flag is unchanged.
 
 ## 22.3.0 — AI context
 

--- a/libs/ui/public/markdown/install/add-components.md
+++ b/libs/ui/public/markdown/install/add-components.md
@@ -3,4 +3,7 @@ kl install button,dropdown,modal
 
 # target a specific project
 kl install modal --project my-angular-app
+
+# accept all external dependency installs without prompting (AI agents / CI)
+kl install button,modal --silent
 ```

--- a/libs/ui/public/markdown/install/create-project.md
+++ b/libs/ui/public/markdown/install/create-project.md
@@ -9,4 +9,10 @@ kl new example --ai-context none
 
 # scaffold Cursor + Copilot context without prompting
 kl new example --ai-context both
+
+# non-interactive (AI agents / CI): bun + AI context none
+kl new example --silent
+
+# non-interactive with overrides
+kl new example --silent --pm pnpm --ai-context both
 ```

--- a/libs/ui/public/markdown/install/init.md
+++ b/libs/ui/public/markdown/install/init.md
@@ -6,4 +6,7 @@ kl init
 
 # skip AI context prompt
 kl init --ai-context none
+
+# non-interactive (AI agents / CI): AI context defaults to none
+kl init --silent
 ```

--- a/libs/ui/public/search-index.json
+++ b/libs/ui/public/search-index.json
@@ -11,7 +11,7 @@
     "title": "Installation",
     "category": "Getting Started",
     "route": "getting-started/installation",
-    "content": "Koala UI – Get Started Koala UI is an Angular component library inspired by shadcn/ui. Components are installed directly into your project via the Koala CLI , giving you full control over the source code. Base dependencies installed by / : @koalarx/utils ≥ 5 and . Full utils API for LLMs: https://utils.koalarx.com/llms.txt. Version compatibility Two support lines (like Angular current + previous): Line Git branch Docs npm dist-tag ------ ------------ ------ -------------- Latest https://ui.koalarx.com/ Previous https://ui.koalarx.com/v{major}/ see release (e.g. for the 22.x line on Angular 21) Older majors are frozen on archive branches named by version (e.g. ) with no publish/deploy. 1. Install the CLI 2. Create a new project During setup you can scaffold AI context (Cursor / GitHub Copilot). Use to skip the prompt. 3. Add components 4. Add AI context (optional) 5. Add resources (optional) Available components - Alert – - Bottom Sheet – - Breadcrumb – - Button – - Calendar – - Checkbox – - Collapse – - Combobox – - Confirm – - DataTable – - Dropdown – - Fieldset – - Inline Filter – - Input CNPJ – - Input CPF – - Input Color – - Input Currency – - Input Field – - Loading – - Login – - Modal – - Pagination – - Radio – - Range – - Select – - Side Window – - Skeleton – - Stepper – - Table – - Tabs – - Textarea – - Text Editor – - Toast – - Toggle – - Tooltip – - Validator – - List Base – - Http Base – - Page Base – - Global Errors – - Rules – - Auth –"
+    "content": "Koala UI – Get Started Koala UI is an Angular component library inspired by shadcn/ui. Components are installed directly into your project via the Koala CLI , giving you full control over the source code. Base dependencies installed by / : @koalarx/utils ≥ 5 and . Full utils API for LLMs: https://utils.koalarx.com/llms.txt. Version compatibility Two support lines (like Angular current + previous): Line Git branch Docs npm dist-tag ------ ------------ ------ -------------- Latest https://ui.koalarx.com/ Previous https://ui.koalarx.com/v{major}/ see release (e.g. for the 22.x line on Angular 21) Older majors are frozen on archive branches named by version (e.g. ) with no publish/deploy. 1. Install the CLI 2. Create a new project During setup you can scaffold AI context (Cursor / GitHub Copilot). Use to skip the prompt. For AI agents or CI, prefer (non-interactive: bun + AI context none unless overridden). 3. Add components Use to accept all external dependency installs without prompting (recommended for AI agents). 4. Add AI context (optional) 5. Add resources (optional) Available components - Alert – - Bottom Sheet – - Breadcrumb – - Button – - Calendar – - Checkbox – - Collapse – - Combobox – - Confirm – - DataTable – - Dropdown – - Fieldset – - Inline Filter – - Input CNPJ – - Input CPF – - Input Color – - Input Currency – - Input Field – - Loading – - Login – - Modal – - Pagination – - Radio – - Range – - Select – - Side Window – - Skeleton – - Stepper – - Table – - Tabs – - Textarea – - Text Editor – - Toast – - Toggle – - Tooltip – - Validator – - List Base – - Http Base – - Page Base – - Global Errors – - Rules – - Auth –"
   },
   {
     "id": "getting-started/installation#version-compatibility",
@@ -35,7 +35,7 @@
     "category": "Getting Started",
     "route": "getting-started/installation",
     "fragment": "2-create-a-new-project",
-    "content": "During setup you can scaffold AI context (Cursor / GitHub Copilot). Use to skip the prompt."
+    "content": "During setup you can scaffold AI context (Cursor / GitHub Copilot). Use to skip the prompt. For AI agents or CI, prefer (non-interactive: bun + AI context none unless overridden)."
   },
   {
     "id": "getting-started/installation#3-add-components",
@@ -43,7 +43,7 @@
     "category": "Getting Started",
     "route": "getting-started/installation",
     "fragment": "3-add-components",
-    "content": ""
+    "content": "Use to accept all external dependency installs without prompting (recommended for AI agents)."
   },
   {
     "id": "getting-started/installation#4-add-ai-context-optional",
@@ -74,7 +74,31 @@
     "title": "Patch notes",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "content": "Koala UI – Patch notes Changelog for anyone using or upgrading projects scaffolded with the Koala UI CLI. Site page: https://ui.koalarx.com/ /getting-started/patch-notes Root CHANGELOG.md mirrors these notes. 22.3.0 — AI context What changed - AI context prompt in and (Cursor, GitHub Copilot, both, or none). - flag to skip the interactive prompt. - New command — scaffolds plus Cursor rules / Copilot instructions. Does not overwrite existing files. - Assets under focused on docs-first, , and Angular (Signals/standalone). - Patch notes documentation on the site and at the repo root. Upgrade On existing projects: , , or both. On new projects, choose in the prompt or use ."
+    "content": "Koala UI – Patch notes Changelog for anyone using or upgrading projects scaffolded with the Koala UI CLI. Site page: https://ui.koalarx.com/ /getting-started/patch-notes Root CHANGELOG.md mirrors these notes. 22.3.1 — CLI --silent What changed - flag on , , and : non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none). Upgrade For AI agents or CI, prefer and . Interactive use without the flag is unchanged. 22.3.0 — AI context What changed - AI context prompt in and (Cursor, GitHub Copilot, both, or none). - flag to skip the interactive prompt. - New command — scaffolds plus Cursor rules / Copilot instructions. Does not overwrite existing files. - Assets under focused on docs-first, , and Angular (Signals/standalone). - Patch notes documentation on the site and at the repo root. Upgrade On existing projects: , , or both. On new projects, choose in the prompt or use ."
+  },
+  {
+    "id": "getting-started/patch-notes#2231-cli---silent",
+    "title": "22.3.1 — CLI --silent",
+    "category": "Getting Started",
+    "route": "getting-started/patch-notes",
+    "fragment": "2231-cli---silent",
+    "content": ""
+  },
+  {
+    "id": "getting-started/patch-notes#what-changed",
+    "title": "What changed",
+    "category": "Getting Started",
+    "route": "getting-started/patch-notes",
+    "fragment": "what-changed",
+    "content": "- flag on , , and : non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none)."
+  },
+  {
+    "id": "getting-started/patch-notes#upgrade",
+    "title": "Upgrade",
+    "category": "Getting Started",
+    "route": "getting-started/patch-notes",
+    "fragment": "upgrade",
+    "content": "For AI agents or CI, prefer and . Interactive use without the flag is unchanged."
   },
   {
     "id": "getting-started/patch-notes#2230-ai-context",
@@ -85,19 +109,19 @@
     "content": ""
   },
   {
-    "id": "getting-started/patch-notes#what-changed",
+    "id": "getting-started/patch-notes#what-changed-2",
     "title": "What changed",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "fragment": "what-changed",
+    "fragment": "what-changed-2",
     "content": "- AI context prompt in and (Cursor, GitHub Copilot, both, or none). - flag to skip the interactive prompt. - New command — scaffolds plus Cursor rules / Copilot instructions. Does not overwrite existing files. - Assets under focused on docs-first, , and Angular (Signals/standalone). - Patch notes documentation on the site and at the repo root."
   },
   {
-    "id": "getting-started/patch-notes#upgrade",
+    "id": "getting-started/patch-notes#upgrade-2",
     "title": "Upgrade",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "fragment": "upgrade",
+    "fragment": "upgrade-2",
     "content": "On existing projects: , , or both. On new projects, choose in the prompt or use ."
   },
   {

--- a/libs/ui/src/app/core/i18n/docs/pages/installation.ts
+++ b/libs/ui/src/app/core/i18n/docs/pages/installation.ts
@@ -15,10 +15,14 @@ export const INSTALLATION_PAGE = {
         otherProse: [
           'kl new e kl init instalam @koalarx/utils ≥ 5 e clsx como dependências base. Veja a documentação do utils e o llms.txt para a API completa.',
           'Durante o setup, a CLI pergunta o contexto AI (Cursor / GitHub Copilot). Use --ai-context none|cursor|github|both para pular o prompt, ou kl add ai-context depois.',
+          'Em agentes de IA ou CI, use --silent: no new/init pula prompts (bun + AI context none por padrão); no install aceita todas as libs externas sem perguntar.',
         ],
       },
       addingComponents: {
         title: 'Adicionar componentes',
+        otherProse: [
+          'Use kl install <componentes> --silent para instalar dependências externas sem prompts interativos.',
+        ],
       },
       addingAiContext: {
         title: 'Adicionar contexto AI',
@@ -48,10 +52,14 @@ export const INSTALLATION_PAGE = {
         otherProse: [
           'kl new and kl init install @koalarx/utils ≥ 5 and clsx as base dependencies. See the utils docs and llms.txt for the full API.',
           'During setup, the CLI prompts for AI context (Cursor / GitHub Copilot). Use --ai-context none|cursor|github|both to skip the prompt, or kl add ai-context later.',
+          'For AI agents or CI, use --silent: on new/init it skips prompts (bun + AI context none by default); on install it accepts all external libs without asking.',
         ],
       },
       addingComponents: {
         title: 'Adding components',
+        otherProse: [
+          'Use kl install <components> --silent to install external dependencies without interactive prompts.',
+        ],
       },
       addingAiContext: {
         title: 'Add AI context',

--- a/libs/ui/src/app/core/i18n/docs/pages/patch-notes.ts
+++ b/libs/ui/src/app/core/i18n/docs/pages/patch-notes.ts
@@ -12,6 +12,15 @@ export const PATCH_NOTES_PAGE = {
         description:
           'A versão publicada do pacote @koalarx/ui aparece no package.json do repositório. O arquivo CHANGELOG.md na raiz espelha estas notas.',
       },
+      v2231: {
+        title: '22.3.1 — CLI --silent',
+        description: 'Modo não interativo na CLI para agentes de IA e CI.',
+        items: [
+          'Flag --silent no kl new, kl init e kl install: aceita libs externas e pula prompts (no new/init defaults bun + AI context none).',
+        ],
+        upgrade:
+          'Em agentes de IA ou CI, prefira kl install … --silent e kl new … --silent. Em uso interativo, o comportamento sem a flag permanece igual.',
+      },
       v2230: {
         title: '22.3.0 — Contexto AI',
         description: 'Scaffolding de contexto para Cursor e GitHub Copilot nos projetos gerados.',
@@ -36,6 +45,15 @@ export const PATCH_NOTES_PAGE = {
         title: 'How to use these notes',
         description:
           'The published @koalarx/ui package version is in the repository package.json. The root CHANGELOG.md mirrors these notes.',
+      },
+      v2231: {
+        title: '22.3.1 — CLI --silent',
+        description: 'Non-interactive CLI mode for AI agents and CI.',
+        items: [
+          '--silent flag on kl new, kl init, and kl install: accepts external libs and skips prompts (on new/init defaults to bun + AI context none).',
+        ],
+        upgrade:
+          'For AI agents or CI, prefer kl install … --silent and kl new … --silent. Interactive use without the flag is unchanged.',
       },
       v2230: {
         title: '22.3.0 — AI context',

--- a/libs/ui/src/app/features/getting-started/installation/installation.page.html
+++ b/libs/ui/src/app/features/getting-started/installation/installation.page.html
@@ -20,11 +20,21 @@
       <i class="fa-solid fa-circle-info"></i>
       <span>{{ copy().sections.creatingNewProject.otherProse[1] }}</span>
     </div>
+
+    <div role="alert" class="alert alert-info alert-dash mt-2">
+      <i class="fa-solid fa-circle-info"></i>
+      <span>{{ copy().sections.creatingNewProject.otherProse[2] }}</span>
+    </div>
   </app-section-content>
 
   <app-section-content class="block mt-10">
     <ng-container title>{{ copy().sections.addingComponents.title }}</ng-container>
     <app-code-viewer language="bash" name="kl" src="markdown/install/add-components.md" />
+
+    <div role="alert" class="alert alert-info alert-dash mt-2">
+      <i class="fa-solid fa-circle-info"></i>
+      <span>{{ copy().sections.addingComponents.otherProse[0] }}</span>
+    </div>
   </app-section-content>
 
   <app-section-content class="block mt-10">

--- a/libs/ui/src/app/features/getting-started/patch-notes/patch-notes.page.html
+++ b/libs/ui/src/app/features/getting-started/patch-notes/patch-notes.page.html
@@ -8,6 +8,22 @@
   </app-section-content>
 
   <app-section-content class="block mt-10">
+    <ng-container title>{{ copy().sections.v2231.title }}</ng-container>
+    <ng-container description>{{ copy().sections.v2231.description }}</ng-container>
+
+    <ul class="list-disc pl-5 mt-4 space-y-2 text-sm font-light">
+      @for (item of copy().sections.v2231.items; track item) {
+        <li>{{ item }}</li>
+      }
+    </ul>
+
+    <div role="alert" class="alert alert-info alert-dash mt-4">
+      <i class="fa-solid fa-circle-info"></i>
+      <span>{{ copy().sections.v2231.upgrade }}</span>
+    </div>
+  </app-section-content>
+
+  <app-section-content class="block mt-10">
     <ng-container title>{{ copy().sections.v2230.title }}</ng-container>
     <ng-container description>{{ copy().sections.v2230.description }}</ng-container>
 

--- a/scripts/generate-llms.js
+++ b/scripts/generate-llms.js
@@ -170,10 +170,13 @@ ${installCli}
 ${createProject}
 
 During setup you can scaffold AI context (Cursor / GitHub Copilot). Use \`--ai-context none|cursor|github|both\` to skip the prompt.
+For AI agents or CI, prefer \`--silent\` (non-interactive: bun + AI context none unless overridden).
 
 ## 3. Add components
 
 ${addComponents}
+
+Use \`kl install … --silent\` to accept all external dependency installs without prompting (recommended for AI agents).
 
 ## 4. Add AI context (optional)
 
@@ -199,6 +202,16 @@ function buildPatchNotesDoc() {
 Changelog for anyone using or upgrading projects scaffolded with the Koala UI CLI.
 Site page: https://ui.koalarx.com/#/getting-started/patch-notes
 Root CHANGELOG.md mirrors these notes.
+
+## 22.3.1 — CLI --silent
+
+### What changed
+
+- \`--silent\` flag on \`kl new\`, \`kl init\`, and \`kl install\`: non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none).
+
+### Upgrade
+
+For AI agents or CI, prefer \`kl install … --silent\` and \`kl new … --silent\`. Interactive use without the flag is unchanged.
 
 ## 22.3.0 — AI context
 


### PR DESCRIPTION
## Summary
- Backport da flag `--silent` para a linha 22.x (`previous-release` / Angular 21).
- `kl install`, `kl new` e `kl init` aceitam `--silent` para não travar em prompts (libs externas; defaults bun + AI context none).
- Docs, patch notes **22.3.1**, LLM e AI context atualizados nesta linha.

## Test plan
- [ ] `bun run test:cli` passa
- [ ] `kl install button --silent` não pergunta sobre deps
- [ ] `kl new demo --silent` / `kl init --silent` sem prompts interativos
- [ ] Patch notes 22.3.1 e get-started citam `--silent`


Made with [Cursor](https://cursor.com)