### PR TITLE
release: 23.0.1 — hotfix CLI --silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ Formato inspirado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/)
 
 A partir de **23.x**, o major de `@koalarx/ui` = major do Angular + 1 (`23` → Angular 22). A linha `22.x` permanece para Angular 21 (`previous-release` / dist-tag `angular-21`).
 
-## [23.0.0] — Angular 22 + Signal Forms
+## [23.0.1] — CLI `--silent`
 
 ### Added
 
 - Flag `--silent` em `kl new`, `kl init` e `kl install` para modo não interativo (aceita libs externas sem prompt; no `new`/`init` defaults `bun` + AI context `none`).
+
+## [23.0.0] — Angular 22 + Signal Forms
 
 ### Changed
 

--- a/libs/ui/public/docs/patch-notes.md
+++ b/libs/ui/public/docs/patch-notes.md
@@ -4,6 +4,16 @@ Changelog for anyone using or upgrading projects scaffolded with the Koala UI CL
 Site page: https://ui.koalarx.com/#/getting-started/patch-notes
 Root CHANGELOG.md mirrors these notes.
 
+## 23.0.1 — CLI --silent
+
+### What changed
+
+- `--silent` flag on `kl new`, `kl init`, and `kl install`: non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none).
+
+### Upgrade
+
+For AI agents or CI, prefer `kl install … --silent` and `kl new … --silent`. Interactive use without the flag is unchanged.
+
 ## 23.0.0 — Angular 22 + Signal Forms
 
 ### What changed
@@ -14,11 +24,10 @@ Root CHANGELOG.md mirrors these notes.
 - Removed control-changes, form-is-valid, and get-value-on-first-change utils (Reactive Forms bridges); CLI no longer scaffolds or installs them as component deps.
 - Functional HTTP interceptors (withInterceptors); NgZone removed from mask/currency.
 - Versioning policy: 22.x = Angular 21; 23.x = Angular 22.
-- `--silent` flag on `kl new`, `kl init`, and `kl install`: non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none).
 
 ### Upgrade
 
-Upgrade consumer apps to Angular 22. Re-run `kl install` for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release). For AI agents, prefer `kl install … --silent` and `kl new … --silent`.
+Upgrade consumer apps to Angular 22. Re-run `kl install` for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release).
 
 ## 22.3.0 — AI context
 

--- a/libs/ui/public/llms-full.txt
+++ b/libs/ui/public/llms-full.txt
@@ -136,6 +136,16 @@ Changelog for anyone using or upgrading projects scaffolded with the Koala UI CL
 Site page: https://ui.koalarx.com/#/getting-started/patch-notes
 Root CHANGELOG.md mirrors these notes.
 
+## 23.0.1 — CLI --silent
+
+### What changed
+
+- `--silent` flag on `kl new`, `kl init`, and `kl install`: non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none).
+
+### Upgrade
+
+For AI agents or CI, prefer `kl install … --silent` and `kl new … --silent`. Interactive use without the flag is unchanged.
+
 ## 23.0.0 — Angular 22 + Signal Forms
 
 ### What changed
@@ -146,11 +156,10 @@ Root CHANGELOG.md mirrors these notes.
 - Removed control-changes, form-is-valid, and get-value-on-first-change utils (Reactive Forms bridges); CLI no longer scaffolds or installs them as component deps.
 - Functional HTTP interceptors (withInterceptors); NgZone removed from mask/currency.
 - Versioning policy: 22.x = Angular 21; 23.x = Angular 22.
-- `--silent` flag on `kl new`, `kl init`, and `kl install`: non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none).
 
 ### Upgrade
 
-Upgrade consumer apps to Angular 22. Re-run `kl install` for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release). For AI agents, prefer `kl install … --silent` and `kl new … --silent`.
+Upgrade consumer apps to Angular 22. Re-run `kl install` for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release).
 
 ## 22.3.0 — AI context
 

--- a/libs/ui/public/search-index.json
+++ b/libs/ui/public/search-index.json
@@ -74,7 +74,31 @@
     "title": "Patch notes",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "content": "Koala UI – Patch notes Changelog for anyone using or upgrading projects scaffolded with the Koala UI CLI. Site page: https://ui.koalarx.com/ /getting-started/patch-notes Root CHANGELOG.md mirrors these notes. 23.0.0 — Angular 22 + Signal Forms What changed - Docs app and CLI pins on Angular 22 / TypeScript 6. - Form controls migrated from ControlValueAccessor to FormValueControl / FormCheckboxControl (Signal Forms; Reactive Forms and ngModel remain compatible on Angular 22). - inline-filter migrated to Signal Forms; builder validators now use FieldValidator (({ value }) = …), not ValidatorFn. - Removed control-changes, form-is-valid, and get-value-on-first-change utils (Reactive Forms bridges); CLI no longer scaffolds or installs them as component deps. - Functional HTTP interceptors (withInterceptors); NgZone removed from mask/currency. - Versioning policy: 22.x = Angular 21; 23.x = Angular 22. - flag on , , and : non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none). Upgrade Upgrade consumer apps to Angular 22. Re-run for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release). For AI agents, prefer and . 22.3.0 — AI context What changed - AI context prompt in and (Cursor, GitHub Copilot, both, or none). - flag to skip the interactive prompt. - New command — scaffolds plus Cursor rules / Copilot instructions. Does not overwrite existing files. - Assets under focused on docs-first, , and Angular (Signals/standalone). - Patch notes documentation on the site and at the repo root. Upgrade On existing projects: , , or both. On new projects, choose in the prompt or use ."
+    "content": "Koala UI – Patch notes Changelog for anyone using or upgrading projects scaffolded with the Koala UI CLI. Site page: https://ui.koalarx.com/ /getting-started/patch-notes Root CHANGELOG.md mirrors these notes. 23.0.1 — CLI --silent What changed - flag on , , and : non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none). Upgrade For AI agents or CI, prefer and . Interactive use without the flag is unchanged. 23.0.0 — Angular 22 + Signal Forms What changed - Docs app and CLI pins on Angular 22 / TypeScript 6. - Form controls migrated from ControlValueAccessor to FormValueControl / FormCheckboxControl (Signal Forms; Reactive Forms and ngModel remain compatible on Angular 22). - inline-filter migrated to Signal Forms; builder validators now use FieldValidator (({ value }) = …), not ValidatorFn. - Removed control-changes, form-is-valid, and get-value-on-first-change utils (Reactive Forms bridges); CLI no longer scaffolds or installs them as component deps. - Functional HTTP interceptors (withInterceptors); NgZone removed from mask/currency. - Versioning policy: 22.x = Angular 21; 23.x = Angular 22. Upgrade Upgrade consumer apps to Angular 22. Re-run for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release). 22.3.0 — AI context What changed - AI context prompt in and (Cursor, GitHub Copilot, both, or none). - flag to skip the interactive prompt. - New command — scaffolds plus Cursor rules / Copilot instructions. Does not overwrite existing files. - Assets under focused on docs-first, , and Angular (Signals/standalone). - Patch notes documentation on the site and at the repo root. Upgrade On existing projects: , , or both. On new projects, choose in the prompt or use ."
+  },
+  {
+    "id": "getting-started/patch-notes#2301-cli---silent",
+    "title": "23.0.1 — CLI --silent",
+    "category": "Getting Started",
+    "route": "getting-started/patch-notes",
+    "fragment": "2301-cli---silent",
+    "content": ""
+  },
+  {
+    "id": "getting-started/patch-notes#what-changed",
+    "title": "What changed",
+    "category": "Getting Started",
+    "route": "getting-started/patch-notes",
+    "fragment": "what-changed",
+    "content": "- flag on , , and : non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none)."
+  },
+  {
+    "id": "getting-started/patch-notes#upgrade",
+    "title": "Upgrade",
+    "category": "Getting Started",
+    "route": "getting-started/patch-notes",
+    "fragment": "upgrade",
+    "content": "For AI agents or CI, prefer and . Interactive use without the flag is unchanged."
   },
   {
     "id": "getting-started/patch-notes#2300-angular-22-signal-forms",
@@ -85,20 +109,20 @@
     "content": ""
   },
   {
-    "id": "getting-started/patch-notes#what-changed",
+    "id": "getting-started/patch-notes#what-changed-2",
     "title": "What changed",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "fragment": "what-changed",
-    "content": "- Docs app and CLI pins on Angular 22 / TypeScript 6. - Form controls migrated from ControlValueAccessor to FormValueControl / FormCheckboxControl (Signal Forms; Reactive Forms and ngModel remain compatible on Angular 22). - inline-filter migrated to Signal Forms; builder validators now use FieldValidator (({ value }) = …), not ValidatorFn. - Removed control-changes, form-is-valid, and get-value-on-first-change utils (Reactive Forms bridges); CLI no longer scaffolds or installs them as component deps. - Functional HTTP interceptors (withInterceptors); NgZone removed from mask/currency. - Versioning policy: 22.x = Angular 21; 23.x = Angular 22. - flag on , , and : non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none)."
+    "fragment": "what-changed-2",
+    "content": "- Docs app and CLI pins on Angular 22 / TypeScript 6. - Form controls migrated from ControlValueAccessor to FormValueControl / FormCheckboxControl (Signal Forms; Reactive Forms and ngModel remain compatible on Angular 22). - inline-filter migrated to Signal Forms; builder validators now use FieldValidator (({ value }) = …), not ValidatorFn. - Removed control-changes, form-is-valid, and get-value-on-first-change utils (Reactive Forms bridges); CLI no longer scaffolds or installs them as component deps. - Functional HTTP interceptors (withInterceptors); NgZone removed from mask/currency. - Versioning policy: 22.x = Angular 21; 23.x = Angular 22."
   },
   {
-    "id": "getting-started/patch-notes#upgrade",
+    "id": "getting-started/patch-notes#upgrade-2",
     "title": "Upgrade",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "fragment": "upgrade",
-    "content": "Upgrade consumer apps to Angular 22. Re-run for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release). For AI agents, prefer and ."
+    "fragment": "upgrade-2",
+    "content": "Upgrade consumer apps to Angular 22. Re-run for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release)."
   },
   {
     "id": "getting-started/patch-notes#2230-ai-context",
@@ -109,19 +133,19 @@
     "content": ""
   },
   {
-    "id": "getting-started/patch-notes#what-changed-2",
+    "id": "getting-started/patch-notes#what-changed-3",
     "title": "What changed",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "fragment": "what-changed-2",
+    "fragment": "what-changed-3",
     "content": "- AI context prompt in and (Cursor, GitHub Copilot, both, or none). - flag to skip the interactive prompt. - New command — scaffolds plus Cursor rules / Copilot instructions. Does not overwrite existing files. - Assets under focused on docs-first, , and Angular (Signals/standalone). - Patch notes documentation on the site and at the repo root."
   },
   {
-    "id": "getting-started/patch-notes#upgrade-2",
+    "id": "getting-started/patch-notes#upgrade-3",
     "title": "Upgrade",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "fragment": "upgrade-2",
+    "fragment": "upgrade-3",
     "content": "On existing projects: , , or both. On new projects, choose in the prompt or use ."
   },
   {

--- a/libs/ui/src/app/core/constants/app-version.ts
+++ b/libs/ui/src/app/core/constants/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '23.0.0';
+export const APP_VERSION = '23.0.1';

--- a/libs/ui/src/app/core/i18n/docs/pages/patch-notes.ts
+++ b/libs/ui/src/app/core/i18n/docs/pages/patch-notes.ts
@@ -12,6 +12,15 @@ export const PATCH_NOTES_PAGE = {
         description:
           'A versão publicada do pacote @koalarx/ui aparece no package.json do repositório. O arquivo CHANGELOG.md na raiz espelha estas notas. A partir de 23.x, o major da lib = major do Angular + 1 (23 → Angular 22). Para Angular 21 use a linha 22.x; para Angular 22 use 23.x.',
       },
+      v2301: {
+        title: '23.0.1 — CLI --silent',
+        description: 'Modo não interativo na CLI para agentes de IA e CI.',
+        items: [
+          'Flag --silent no kl new, kl init e kl install: aceita libs externas e pula prompts (no new/init defaults bun + AI context none).',
+        ],
+        upgrade:
+          'Em agentes de IA ou CI, prefira kl install … --silent e kl new … --silent. Em uso interativo, o comportamento sem a flag permanece igual.',
+      },
       v2300: {
         title: '23.0.0 — Angular 22 + Signal Forms',
         description:
@@ -23,10 +32,9 @@ export const PATCH_NOTES_PAGE = {
           'Removidos utils control-changes, form-is-valid e get-value-on-first-change (ponte Reactive Forms); CLI não os instala mais no scaffold nem como dep de componentes.',
           'Interceptors HTTP funcionais (withInterceptors); remoção de NgZone em mask/currency.',
           'Política de versão: 22.x = Angular 21; 23.x = Angular 22.',
-          'Flag --silent no kl new, kl init e kl install: modo não interativo (aceita libs externas e pula prompts; no new/init defaults bun + AI context none).',
         ],
         upgrade:
-          'Atualize o projeto consumidor para Angular 22. Reinstale componentes de formulário (e inline-filter) com kl install quando quiser o novo código FormValueControl/Signal Forms. Se passar validators no InlineFilterBuilder, troque ValidatorFn por FieldValidator de Signal Forms. Apague control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts se existirem e troque usos por field().value() / field().valid(). Para Angular 21, use a linha 22.x (dist-tag angular-21 após o release). Em agentes de IA, prefira kl install … --silent e kl new … --silent.',
+          'Atualize o projeto consumidor para Angular 22. Reinstale componentes de formulário (e inline-filter) com kl install quando quiser o novo código FormValueControl/Signal Forms. Se passar validators no InlineFilterBuilder, troque ValidatorFn por FieldValidator de Signal Forms. Apague control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts se existirem e troque usos por field().value() / field().valid(). Para Angular 21, use a linha 22.x (dist-tag angular-21 após o release).',
       },
       v2230: {
         title: '22.3.0 — Contexto AI',
@@ -53,6 +61,15 @@ export const PATCH_NOTES_PAGE = {
         description:
           'The published @koalarx/ui package version is in the repository package.json. The root CHANGELOG.md mirrors these notes. From 23.x onward, library major = Angular major + 1 (23 → Angular 22). For Angular 21 use the 22.x line; for Angular 22 use 23.x.',
       },
+      v2301: {
+        title: '23.0.1 — CLI --silent',
+        description: 'Non-interactive CLI mode for AI agents and CI.',
+        items: [
+          '--silent flag on kl new, kl init, and kl install: accepts external libs and skips prompts (on new/init defaults to bun + AI context none).',
+        ],
+        upgrade:
+          'For AI agents or CI, prefer kl install … --silent and kl new … --silent. Interactive use without the flag is unchanged.',
+      },
       v2300: {
         title: '23.0.0 — Angular 22 + Signal Forms',
         description:
@@ -64,10 +81,9 @@ export const PATCH_NOTES_PAGE = {
           'Removed control-changes, form-is-valid, and get-value-on-first-change utils (Reactive Forms bridges); CLI no longer scaffolds or installs them as component deps.',
           'Functional HTTP interceptors (withInterceptors); NgZone removed from mask/currency.',
           'Versioning policy: 22.x = Angular 21; 23.x = Angular 22.',
-          '--silent flag on kl new, kl init, and kl install: non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none).',
         ],
         upgrade:
-          'Upgrade consumer apps to Angular 22. Re-run kl install for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release). For AI agents, prefer kl install … --silent and kl new … --silent.',
+          'Upgrade consumer apps to Angular 22. Re-run kl install for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release).',
       },
       v2230: {
         title: '22.3.0 — AI context',

--- a/libs/ui/src/app/features/getting-started/patch-notes/patch-notes.page.html
+++ b/libs/ui/src/app/features/getting-started/patch-notes/patch-notes.page.html
@@ -8,6 +8,22 @@
   </app-section-content>
 
   <app-section-content class="block mt-10">
+    <ng-container title>{{ copy().sections.v2301.title }}</ng-container>
+    <ng-container description>{{ copy().sections.v2301.description }}</ng-container>
+
+    <ul class="list-disc pl-5 mt-4 space-y-2 text-sm font-light">
+      @for (item of copy().sections.v2301.items; track item) {
+        <li>{{ item }}</li>
+      }
+    </ul>
+
+    <div role="alert" class="alert alert-info alert-dash mt-4">
+      <i class="fa-solid fa-circle-info"></i>
+      <span>{{ copy().sections.v2301.upgrade }}</span>
+    </div>
+  </app-section-content>
+
+  <app-section-content class="block mt-10">
     <ng-container title>{{ copy().sections.v2300.title }}</ng-container>
     <ng-container description>{{ copy().sections.v2300.description }}</ng-container>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/ui",
-  "version": "23.0.0",
+  "version": "23.0.1",
   "scripts": {
     "build": "bun scripts/build",
     "build:doc": "bun run build:docs",

--- a/scripts/generate-llms.js
+++ b/scripts/generate-llms.js
@@ -203,6 +203,16 @@ Changelog for anyone using or upgrading projects scaffolded with the Koala UI CL
 Site page: https://ui.koalarx.com/#/getting-started/patch-notes
 Root CHANGELOG.md mirrors these notes.
 
+## 23.0.1 — CLI --silent
+
+### What changed
+
+- \`--silent\` flag on \`kl new\`, \`kl init\`, and \`kl install\`: non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none).
+
+### Upgrade
+
+For AI agents or CI, prefer \`kl install … --silent\` and \`kl new … --silent\`. Interactive use without the flag is unchanged.
+
 ## 23.0.0 — Angular 22 + Signal Forms
 
 ### What changed
@@ -213,11 +223,10 @@ Root CHANGELOG.md mirrors these notes.
 - Removed control-changes, form-is-valid, and get-value-on-first-change utils (Reactive Forms bridges); CLI no longer scaffolds or installs them as component deps.
 - Functional HTTP interceptors (withInterceptors); NgZone removed from mask/currency.
 - Versioning policy: 22.x = Angular 21; 23.x = Angular 22.
-- \`--silent\` flag on \`kl new\`, \`kl init\`, and \`kl install\`: non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none).
 
 ### Upgrade
 
-Upgrade consumer apps to Angular 22. Re-run \`kl install\` for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release). For AI agents, prefer \`kl install … --silent\` and \`kl new … --silent\`.
+Upgrade consumer apps to Angular 22. Re-run \`kl install\` for form components (and inline-filter) to pick up FormValueControl/Signal Forms. If you pass validators to InlineFilterBuilder, replace ValidatorFn with Signal Forms FieldValidator. Delete control-changes.ts / form-is-valid.ts / get-value-on-first-change.ts if present and replace usages with field().value() / field().valid(). For Angular 21, stay on the 22.x line (angular-21 dist-tag after release).
 
 ## 22.3.0 — AI context
 


### PR DESCRIPTION
## Summary
- Bump `@koalarx/ui` **23.0.0 → 23.0.1** para publicar no npm (`latest`) a flag `--silent`.
- Patch notes / CHANGELOG / LLM alinhados à 23.0.1 (separada do 23.0.0 já publicado).

O workflow **NPM PUBLISH** dispara só quando `package.json` muda.

## Test plan
- [ ] Após merge, workflow NPM PUBLISH em `main` publica `23.0.1` com tag `latest`
- [ ] `npm view @koalarx/ui version` → `23.0.1`
- [ ] Docs / patch notes mostram 23.0.1


Made with [Cursor](https://cursor.com)