### PR TITLE
release: 22.3.1 — hotfix CLI --silent

### DIFF
--- a/libs/ui/src/app/core/constants/app-version.ts
+++ b/libs/ui/src/app/core/constants/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '22.3.0';
+export const APP_VERSION = '22.3.1';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/ui",
-  "version": "22.3.0",
+  "version": "22.3.1",
   "scripts": {
     "build": "bun scripts/build",
     "build:doc": "bun run build:docs",


### PR DESCRIPTION
## Summary
- Bump `@koalarx/ui` **22.3.0 → 22.3.1** para publicar no npm (`angular-21`) a flag `--silent`.
- Patch notes 22.3.1 já estavam no merge do hotfix; este PR só versiona o pacote.

O workflow **NPM PUBLISH** dispara só quando `package.json` muda.

## Test plan
- [ ] Após merge, workflow NPM PUBLISH em `previous-release` publica `22.3.1` com tag `angular-21`
- [ ] `npm view @koalarx/ui@22.3.1 version` e dist-tag `angular-21` apontam para 22.3.1


Made with [Cursor](https://cursor.com)