### PR TITLE
Enhance calendar and inline filter components

### DIFF
--- a/libs/ui/src/app/shared/components/calendar/calendar.css
+++ b/libs/ui/src/app/shared/components/calendar/calendar.css
@@ -4,6 +4,7 @@ calendar-select-year::part(label) {
 
 calendar-select-year::part(select) {
   background-color: var(--color-base-100);
+  color: var(--color-base-content);
   border: none;
   font-weight: 700;
   font-size: 1rem;

--- a/libs/ui/src/app/shared/components/calendar/calendar.html
+++ b/libs/ui/src/app/shared/components/calendar/calendar.html
@@ -21,8 +21,12 @@
     [class.rounded-t-box]="squareBottom()"
     [value]="value()"
   >
-    <i aria-label="Previous" class="fa-solid fa-chevron-left" slot="previous"></i>
-    <i aria-label="Next" class="fa-solid fa-chevron-right" slot="next"></i>
+    <i
+      aria-label="Previous"
+      class="fa-solid fa-chevron-left text-base-content/50"
+      slot="previous"
+    ></i>
+    <i aria-label="Next" class="fa-solid fa-chevron-right text-base-content/50" slot="next"></i>
     <calendar-select-year slot="heading" max-years="100" />
     <calendar-month />
   </calendar-date>

--- a/libs/ui/src/app/shared/components/calendar/input-calendar.ts
+++ b/libs/ui/src/app/shared/components/calendar/input-calendar.ts
@@ -10,10 +10,12 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { KlDate } from '@koalarx/utils/KlDate';
 import 'cally';
 import { Calendar } from '.';
 import { Mask } from '../../directives/mask.directive';
+import { Dropdown, DropdownContainer } from '../dropdown';
 import type { InputSize } from '../input-field';
 import { Input } from '../input-field';
 import { setupMonthDisplayYearEffect } from './effects/setup-input-calendar-effects';
@@ -30,8 +32,6 @@ import {
 import { InputCalendarFormat, InputCalendarType } from './input-calendar.types';
 import { InputCalendarMonthPickerComponent } from './parts/input-calendar-month-picker.component';
 import { InputCalendarTimeRowComponent } from './parts/input-calendar-time-row.component';
-import { Dropdown, DropdownContainer } from '../dropdown';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 const RANGE_SEPARATOR = ' - ';
 
@@ -88,13 +88,7 @@ export class InputCalendar implements ControlValueAccessor {
   readonly monthOptions = createMonthOptions('pt-BR');
 
   constructor() {
-    effect(() => {
-      if (this.disabled()) {
-        this.isDisabled.set(true);
-      } else {
-        this.isDisabled.set(false);
-      }
-    });
+    effect(() => this.isDisabled.set(this.disabled()));
 
     effect(() => {
       if (this.type() === 'daterange') {

--- a/libs/ui/src/app/shared/components/inline-filter/parts/picker/mobile-picker.html
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/picker/mobile-picker.html
@@ -55,7 +55,7 @@
 
                   <app-select
                     #selectField
-                    size="xs"
+                    size="md"
                     [options]="options"
                     [placeholder]="field.placeholder || 'Select an option'"
                     [multiple]="field.multiple"
@@ -67,7 +67,7 @@
 
                   <app-combobox
                     #comboboxField
-                    size="xs"
+                    size="md"
                     [options]="options"
                     [placeholder]="field.placeholder || 'Select an option'"
                     [multiple]="field.multiple"

--- a/libs/ui/src/app/shared/components/inline-filter/wrapper.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/wrapper.ts
@@ -59,7 +59,7 @@ export class Wrapper implements OnInit {
 
       this.payload.emit(queryParams);
 
-      queueMicrotask(() => this.router.navigate([], { queryParams, queryParamsHandling: 'merge' }));
+      queueMicrotask(() => this.router.navigate([], { queryParams }));
     }
   }
 

--- a/libs/ui/src/app/shared/components/inline-filter/wrapper.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/wrapper.ts
@@ -59,7 +59,7 @@ export class Wrapper implements OnInit {
 
       this.payload.emit(queryParams);
 
-      queueMicrotask(() => this.router.navigate([], { queryParams }));
+      queueMicrotask(() => this.router.navigate([], { queryParams, queryParamsHandling: 'merge' }));
     }
   }
 

--- a/libs/ui/src/app/shared/components/inline-filter/wrapper.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/wrapper.ts
@@ -1,12 +1,20 @@
 import { Button } from '@/shared/components/button';
 import { isMobile } from '@/shared/utils/is-mobile';
-import { Component, inject, input, OnInit, output, signal } from '@angular/core';
+import { Component, inject, Injector, input, OnInit, output, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { BottomSheet } from '../bottom-sheet';
-import { InlineFilterConfig } from './config';
+import { InlineFilterConfig, InlineFilterField } from './config';
 import { InputPicker } from './parts/picker/input-picker';
 import { MobilePicker } from './parts/picker/mobile-picker';
+import { queryParamsToOptions } from './utils/query-params-to-options';
+import { optionsToQueryParams } from './utils/options-to-query-params';
+
+interface QueryParams {
+  [key: string]: any;
+  page?: string;
+  pageSize?: string;
+}
 
 @Component({
   selector: 'app-inline-filter',
@@ -14,8 +22,10 @@ import { MobilePicker } from './parts/picker/mobile-picker';
   imports: [InputPicker, Button],
 })
 export class Wrapper implements OnInit {
+  private readonly injector = inject(Injector);
   private readonly bottomSheet = inject(BottomSheet);
   private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly router = inject(Router);
 
   private readonly queryParams = toSignal(this.activatedRoute.queryParams);
 
@@ -29,9 +39,27 @@ export class Wrapper implements OnInit {
 
   ngOnInit(): void {
     if (this.isMobile) {
-      const queryParams = this.queryParams() ?? {};
+      let queryParams = { ...(this.queryParams() ?? {}) } as QueryParams;
+
+      delete queryParams.page;
+      delete queryParams.pageSize;
+
+      const selectedOptions = signal<InlineFilterField[]>([]);
+
+      queryParamsToOptions(
+        this.config().fields,
+        selectedOptions,
+        this.queryParams() ?? {},
+        this.injector,
+      );
+
+      queryParams = optionsToQueryParams(selectedOptions());
+
       this.qtyFieldsFiltered.set(Object.keys(queryParams).length);
+
       this.payload.emit(queryParams);
+
+      queueMicrotask(() => this.router.navigate([], { queryParams }));
     }
   }
 

--- a/libs/ui/src/app/shared/components/pagination/pagination.html
+++ b/libs/ui/src/app/shared/components/pagination/pagination.html
@@ -1,4 +1,9 @@
-<div class="flex justify-between items-center gap-10">
+<div
+  class="flex justify-between items-center bg-base-200 dark:bg-base-100 gap-10 py-2 px-3"
+  [class.flex-wrap]="isMobile"
+  [class.gap-2!]="isMobile"
+  [class.justify-center]="isMobile"
+>
   <div class="flex items-center gap-2 dark:text-neutral-500">
     <span class="whitespace-nowrap font-light" [class]="textSizeClass()">
       Items per page limit

--- a/libs/ui/src/app/shared/components/pagination/pagination.ts
+++ b/libs/ui/src/app/shared/components/pagination/pagination.ts
@@ -1,3 +1,4 @@
+import { isMobile } from '@/shared/utils/is-mobile';
 import { Component, computed, effect, inject, input, linkedSignal, output } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
@@ -30,6 +31,8 @@ export class Pagination {
     ),
     { initialValue: { page: 1, pageSize: 10 } },
   );
+
+  readonly isMobile = isMobile();
 
   readonly pageSizeOptions: SelectOption<number>[] = [
     { label: '10', value: 10, data: undefined },

--- a/libs/ui/src/app/shared/components/radio/radio.ts
+++ b/libs/ui/src/app/shared/components/radio/radio.ts
@@ -107,12 +107,18 @@ export class Radio {
     });
   }
 
-  protected handleClick(event: MouseEvent) {
+  private tryClearSelection(event: Event) {
     const radio = this.elementRef.nativeElement;
     const control = this.injector.get(NgControl, null, { self: true, optional: true })?.control;
     const currentValue = control?.value;
 
-    if (String(currentValue ?? '') !== radio.value) {
+    // Native / signal forms: compare against the group's checked radio value when no NgControl.
+    const selectedInGroup =
+      currentValue !== undefined && currentValue !== null
+        ? String(currentValue) === radio.value
+        : radio.checked;
+
+    if (!selectedInGroup) {
       return;
     }
 
@@ -128,25 +134,12 @@ export class Radio {
     });
   }
 
+  protected handleClick(event: MouseEvent) {
+    this.tryClearSelection(event);
+  }
+
   protected handleSpace(event: Event) {
-    const radio = this.elementRef.nativeElement;
-    const control = this.injector.get(NgControl, null, { self: true, optional: true })?.control;
-    const currentValue = control?.value;
-
-    if (String(currentValue ?? '') !== radio.value) {
-      return;
-    }
-
-    event.preventDefault();
-    queueMicrotask(() => {
-      control?.setValue(null);
-      control?.markAsTouched();
-      this.clearGroupSelection(radio);
-
-      requestAnimationFrame(() => {
-        this.clearGroupSelection(radio);
-      });
-    });
+    this.tryClearSelection(event);
   }
 
   private clearGroupSelection(currentRadio: HTMLInputElement) {

--- a/libs/ui/src/app/shared/components/toast/toast-alert.html
+++ b/libs/ui/src/app/shared/components/toast/toast-alert.html
@@ -2,7 +2,7 @@
   class="flex flex-col rounded-lg border-2 border-base-300 bg-base-100 cursor-pointer animate-fade-down-in"
   (click)="toastRef.dismiss()"
 >
-  <div class="flex items-center justify-between gap-5 py-2 px-5 max-w-[30vw]">
+  <div class="flex items-center justify-between gap-5 py-2 px-5 md:max-w-[30vw]">
     @switch (config.type) {
       @case ('success') {
         <i class="fa-solid fa-circle-check text-success"></i>
@@ -20,7 +20,7 @@
 
     <div class="flex flex-col text-sm">
       <h3 class="text-sm font-semibold empty:hidden">{{ config.title }}</h3>
-      <p>{{ config.message }}</p>
+      <p [innerHTML]="config.message"></p>
     </div>
 
     <button type="button" appButton btnVariant="neutral" btnSize="xs">Ok</button>


### PR DESCRIPTION
- Updated calendar styles to improve text visibility.
- Modified calendar HTML to apply new text color for navigation icons.
- Refactored input-calendar initialization logic for better readability.
- Enhanced inline filter component to manage query parameters more effectively, including mobile-specific adjustments.
- Adjusted mobile picker size for better UI consistency.
- Improved pagination layout for mobile responsiveness.
- Refined radio button selection logic for clearer event handling.
- Updated toast alert to support HTML content in messages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mobile filter init rewrites query params and navigates on load; toast `innerHTML` is risky if messages are not trusted.
> 
> **Overview**
> **Mobile inline filters** now hydrate from the URL on init: pagination query keys are stripped, fields are parsed via `queryParamsToOptions`, params are normalized with `optionsToQueryParams`, the filter count and `payload` are updated, and the router syncs the URL in a microtask.
> 
> **Calendar** styling adds theme-aware text on the year select and muted chevron icons. **Mobile filter picker** bumps select/combobox from `xs` to `md`. **Pagination** gets a padded bar background and mobile-specific wrapping/centering. **Radio** click-to-clear is consolidated into `tryClearSelection`, including when there is no `NgControl` (uses `radio.checked`). **Toasts** allow HTML in messages and only cap width on `md+`. Minor **input-calendar** cleanup (imports, disabled effect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df2c422cfe2e34fb399afb4f27cac6fdf2f5a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->