### PR TITLE
Remove docs leakage from CLI and update upgrade instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ O conteúdo principal da página web vive em `libs/ui/src/app/core/i18n/docs/pag
 
 Formato inspirado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/).
 
+## [22.3.3] — Sem vazamento de docs na CLI
+
+### Fixed
+
+- `kl new` deixa de copiar o `index.html` das docs (script de migração hash/locale e redirect `/v{n}/` → `ui.koalarx.com`).
+- `kl install auth` deixa de depender de `LocaleService` / i18n das docs (que não eram publicados no pacote).
+
+### Upgrade
+
+1. Em projetos já gerados: remova o `<script>` de migração de hash/versão do `src/index.html`.
+2. Se usa `auth`: `kl install auth` (ou remova imports de `../i18n/locale.service` nos arquivos de core copiados).
+
 ## [22.3.1] — CLI `--silent`
 
 ### Added

--- a/libs/cli/assets/templates/index.html
+++ b/libs/cli/assets/templates/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en" class="dark" data-theme="koala">
+  <head>
+    <meta charset="utf-8" />
+    <title>__PROJECT_NAME__</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Unbounded:wght@200..900&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/libs/cli/commands/new.ts
+++ b/libs/cli/commands/new.ts
@@ -81,8 +81,8 @@ async function createAngularProject(
 function createFolderStructure(name: string) {
   rmSync(`${name}/src/app/app.css`);
 
-  const indexHtml = readFileSync(`${originPath}/ui/index.html`, 'utf-8');
-  writeFileSync(`${name}/src/index.html`, indexHtml.replace('@koalarx/ui', name));
+  const indexHtml = readFileSync(`${originPath}/cli/assets/templates/index.html`, 'utf-8');
+  writeFileSync(`${name}/src/index.html`, indexHtml.replaceAll('__PROJECT_NAME__', name));
 
   const appTs = readFileSync(`${name}/src/app/app.ts`, 'utf-8');
   writeFileSync(

--- a/libs/ui/public/docs/patch-notes.md
+++ b/libs/ui/public/docs/patch-notes.md
@@ -4,6 +4,17 @@ Changelog for anyone using or upgrading projects scaffolded with the Koala UI CL
 Site page: https://ui.koalarx.com/#/getting-started/patch-notes
 Root CHANGELOG.md mirrors these notes.
 
+## 22.3.3 — No docs leakage in the CLI
+
+### What changed
+
+- `kl new` uses a consumer `index.html` (no docs version/locale migration script).
+- `kl install auth` no longer depends on `LocaleService` / docs i18n.
+
+### Upgrade
+
+On existing projects: remove the hash/version migration `<script>` from `src/index.html`. If you use auth, reinstall with `kl install auth` (or drop `../i18n/locale.service` imports from the copied core files).
+
 ## 22.3.1 — CLI --silent
 
 ### What changed

--- a/libs/ui/public/llms-full.txt
+++ b/libs/ui/public/llms-full.txt
@@ -136,6 +136,17 @@ Changelog for anyone using or upgrading projects scaffolded with the Koala UI CL
 Site page: https://ui.koalarx.com/#/getting-started/patch-notes
 Root CHANGELOG.md mirrors these notes.
 
+## 22.3.3 — No docs leakage in the CLI
+
+### What changed
+
+- `kl new` uses a consumer `index.html` (no docs version/locale migration script).
+- `kl install auth` no longer depends on `LocaleService` / docs i18n.
+
+### Upgrade
+
+On existing projects: remove the hash/version migration `<script>` from `src/index.html`. If you use auth, reinstall with `kl install auth` (or drop `../i18n/locale.service` imports from the copied core files).
+
 ## 22.3.1 — CLI --silent
 
 ### What changed

--- a/libs/ui/public/search-index.json
+++ b/libs/ui/public/search-index.json
@@ -74,7 +74,31 @@
     "title": "Patch notes",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "content": "Koala UI – Patch notes Changelog for anyone using or upgrading projects scaffolded with the Koala UI CLI. Site page: https://ui.koalarx.com/ /getting-started/patch-notes Root CHANGELOG.md mirrors these notes. 22.3.1 — CLI --silent What changed - flag on , , and : non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none). Upgrade For AI agents or CI, prefer and . Interactive use without the flag is unchanged. 22.3.0 — AI context What changed - AI context prompt in and (Cursor, GitHub Copilot, both, or none). - flag to skip the interactive prompt. - New command — scaffolds plus Cursor rules / Copilot instructions. Does not overwrite existing files. - Assets under focused on docs-first, , and Angular (Signals/standalone). - Patch notes documentation on the site and at the repo root. Upgrade On existing projects: , , or both. On new projects, choose in the prompt or use ."
+    "content": "Koala UI – Patch notes Changelog for anyone using or upgrading projects scaffolded with the Koala UI CLI. Site page: https://ui.koalarx.com/ /getting-started/patch-notes Root CHANGELOG.md mirrors these notes. 22.3.3 — No docs leakage in the CLI What changed - uses a consumer (no docs version/locale migration script). - no longer depends on / docs i18n. Upgrade On existing projects: remove the hash/version migration from . If you use auth, reinstall with (or drop imports from the copied core files). 22.3.1 — CLI --silent What changed - flag on , , and : non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none). Upgrade For AI agents or CI, prefer and . Interactive use without the flag is unchanged. 22.3.0 — AI context What changed - AI context prompt in and (Cursor, GitHub Copilot, both, or none). - flag to skip the interactive prompt. - New command — scaffolds plus Cursor rules / Copilot instructions. Does not overwrite existing files. - Assets under focused on docs-first, , and Angular (Signals/standalone). - Patch notes documentation on the site and at the repo root. Upgrade On existing projects: , , or both. On new projects, choose in the prompt or use ."
+  },
+  {
+    "id": "getting-started/patch-notes#2233-no-docs-leakage-in-the-cli",
+    "title": "22.3.3 — No docs leakage in the CLI",
+    "category": "Getting Started",
+    "route": "getting-started/patch-notes",
+    "fragment": "2233-no-docs-leakage-in-the-cli",
+    "content": ""
+  },
+  {
+    "id": "getting-started/patch-notes#what-changed",
+    "title": "What changed",
+    "category": "Getting Started",
+    "route": "getting-started/patch-notes",
+    "fragment": "what-changed",
+    "content": "- uses a consumer (no docs version/locale migration script). - no longer depends on / docs i18n."
+  },
+  {
+    "id": "getting-started/patch-notes#upgrade",
+    "title": "Upgrade",
+    "category": "Getting Started",
+    "route": "getting-started/patch-notes",
+    "fragment": "upgrade",
+    "content": "On existing projects: remove the hash/version migration from . If you use auth, reinstall with (or drop imports from the copied core files)."
   },
   {
     "id": "getting-started/patch-notes#2231-cli---silent",
@@ -85,19 +109,19 @@
     "content": ""
   },
   {
-    "id": "getting-started/patch-notes#what-changed",
+    "id": "getting-started/patch-notes#what-changed-2",
     "title": "What changed",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "fragment": "what-changed",
+    "fragment": "what-changed-2",
     "content": "- flag on , , and : non-interactive mode (accepts external libs and skips prompts; on new/init defaults to bun + AI context none)."
   },
   {
-    "id": "getting-started/patch-notes#upgrade",
+    "id": "getting-started/patch-notes#upgrade-2",
     "title": "Upgrade",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "fragment": "upgrade",
+    "fragment": "upgrade-2",
     "content": "For AI agents or CI, prefer and . Interactive use without the flag is unchanged."
   },
   {
@@ -109,19 +133,19 @@
     "content": ""
   },
   {
-    "id": "getting-started/patch-notes#what-changed-2",
+    "id": "getting-started/patch-notes#what-changed-3",
     "title": "What changed",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "fragment": "what-changed-2",
+    "fragment": "what-changed-3",
     "content": "- AI context prompt in and (Cursor, GitHub Copilot, both, or none). - flag to skip the interactive prompt. - New command — scaffolds plus Cursor rules / Copilot instructions. Does not overwrite existing files. - Assets under focused on docs-first, , and Angular (Signals/standalone). - Patch notes documentation on the site and at the repo root."
   },
   {
-    "id": "getting-started/patch-notes#upgrade-2",
+    "id": "getting-started/patch-notes#upgrade-3",
     "title": "Upgrade",
     "category": "Getting Started",
     "route": "getting-started/patch-notes",
-    "fragment": "upgrade-2",
+    "fragment": "upgrade-3",
     "content": "On existing projects: , , or both. On new projects, choose in the prompt or use ."
   },
   {

--- a/libs/ui/src/app/core/constants/app-version.ts
+++ b/libs/ui/src/app/core/constants/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '22.3.3';
+export const APP_VERSION = '22.3.4';

--- a/libs/ui/src/app/core/constants/app-version.ts
+++ b/libs/ui/src/app/core/constants/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '22.3.2';
+export const APP_VERSION = '22.3.3';

--- a/libs/ui/src/app/core/guards/route-access.guard.ts
+++ b/libs/ui/src/app/core/guards/route-access.guard.ts
@@ -9,20 +9,18 @@ import {
 } from '@angular/router';
 import { filter } from 'rxjs/internal/operators/filter';
 import { map } from 'rxjs/internal/operators/map';
-import { LocaleService } from '../i18n/locale.service';
 import { AuthorizationService, LOGIN_ROUTE } from '../security/authorization.service';
 import { RouteData } from '../utils/routes-registre';
 
 @Injectable()
 export class RouteAccessGuard implements CanActivate {
   private readonly router = inject(Router);
-  private readonly localeService = inject(LocaleService);
   private readonly authorization = inject(AuthorizationService);
   private readonly loggedUser = toObservable(this.authorization.loggedUser);
 
   canActivate(route: ActivatedRouteSnapshot): MaybeAsync<GuardResult> {
     if (!this.authorization.hasToken()) {
-      void this.router.navigateByUrl(this.localeService.path(LOGIN_ROUTE));
+      void this.router.navigateByUrl(`/${LOGIN_ROUTE}`);
       return false;
     }
 

--- a/libs/ui/src/app/core/i18n/docs/pages/patch-notes.ts
+++ b/libs/ui/src/app/core/i18n/docs/pages/patch-notes.ts
@@ -12,6 +12,17 @@ export const PATCH_NOTES_PAGE = {
         description:
           'A versão publicada do pacote @koalarx/ui aparece no package.json do repositório. O arquivo CHANGELOG.md na raiz espelha estas notas.',
       },
+      v2233: {
+        title: '22.3.3 — Sem vazamento de docs na CLI',
+        description:
+          'Templates e resources instaláveis deixam de levar artefatos só da app de documentação.',
+        items: [
+          'kl new usa index.html de consumidor (sem script de versão/locale das docs).',
+          'kl install auth não depende mais de LocaleService / i18n das docs.',
+        ],
+        upgrade:
+          'Em projetos já gerados: remova o <script> de migração de hash/versão do src/index.html. Se usa auth, reinstale com kl install auth (ou remova imports de ../i18n/locale.service nos arquivos de core copiados).',
+      },
       v2231: {
         title: '22.3.1 — CLI --silent',
         description: 'Modo não interativo na CLI para agentes de IA e CI.',
@@ -45,6 +56,17 @@ export const PATCH_NOTES_PAGE = {
         title: 'How to use these notes',
         description:
           'The published @koalarx/ui package version is in the repository package.json. The root CHANGELOG.md mirrors these notes.',
+      },
+      v2233: {
+        title: '22.3.3 — No docs leakage in the CLI',
+        description:
+          'Installable templates and resources no longer ship documentation-app-only artifacts.',
+        items: [
+          'kl new uses a consumer index.html (no docs version/locale migration script).',
+          'kl install auth no longer depends on LocaleService / docs i18n.',
+        ],
+        upgrade:
+          'On existing projects: remove the hash/version migration <script> from src/index.html. If you use auth, reinstall with kl install auth (or drop ../i18n/locale.service imports from the copied core files).',
       },
       v2231: {
         title: '22.3.1 — CLI --silent',

--- a/libs/ui/src/app/core/security/authorization.service.ts
+++ b/libs/ui/src/app/core/security/authorization.service.ts
@@ -3,7 +3,6 @@ import { computed, effect, inject, Injectable, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { jwtDecode } from 'jwt-decode';
 import { tap } from 'rxjs/internal/operators/tap';
-import { LocaleService } from '../i18n/locale.service';
 import { Credentials } from '../models/credentials';
 import { LoggedUser } from '../models/logged-user';
 import { Authentication } from '../utils/authentication';
@@ -25,7 +24,6 @@ export interface AuthEvent {
 export class AuthorizationService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
-  private readonly localeService = inject(LocaleService);
   private readonly hostApi = 'https://dummyjson.com';
   private readonly _loggedUser = signal<LoggedUser | undefined>(undefined);
   private readonly _event = signal<AuthEvent | undefined>(undefined);
@@ -37,7 +35,7 @@ export class AuthorizationService {
       if (accessToken && !this._loggedUser()) {
         this._event.set({ type: 'loadingUserInfo', data: accessToken });
       } else if (!accessToken && !this.isAuthOptionalRoute()) {
-        void this.router.navigateByUrl(this.localeService.path(LOGIN_ROUTE));
+        void this.router.navigateByUrl(`/${LOGIN_ROUTE}`);
       }
     });
 
@@ -55,16 +53,17 @@ export class AuthorizationService {
           }
           break;
         case 'authenticated':
-          if (this.routeWithoutLocale() === `/${LOGIN_ROUTE}`) {
-            void this.router.navigateByUrl(this.localeService.homeRoute());
+          if (this.currentPath() === `/${LOGIN_ROUTE}`) {
+            void this.router.navigateByUrl('/');
           }
           break;
       }
     });
   }
 
-  private routeWithoutLocale() {
+  private currentPath() {
     const parts = this.router.url.split(/[?#]/)[0].split('/').filter(Boolean);
+    // Docs site prefixes routes with locale (`/pt`, `/en`); consumers usually do not.
     if (parts[0] === 'pt' || parts[0] === 'en') {
       parts.shift();
     }
@@ -96,7 +95,7 @@ export class AuthorizationService {
   }
 
   private isAuthOptionalRoute() {
-    return PUBLIC_ROUTES.includes(this.routeWithoutLocale());
+    return PUBLIC_ROUTES.includes(this.currentPath());
   }
 
   get loggedUser() {
@@ -169,7 +168,7 @@ export class AuthorizationService {
     this._event.set(undefined);
 
     if (!this.isAuthOptionalRoute()) {
-      void this.router.navigateByUrl(this.localeService.path(LOGIN_ROUTE));
+      void this.router.navigateByUrl(`/${LOGIN_ROUTE}`);
     }
   }
 }

--- a/libs/ui/src/app/features/getting-started/patch-notes/patch-notes.page.html
+++ b/libs/ui/src/app/features/getting-started/patch-notes/patch-notes.page.html
@@ -8,6 +8,22 @@
   </app-section-content>
 
   <app-section-content class="block mt-10">
+    <ng-container title>{{ copy().sections.v2233.title }}</ng-container>
+    <ng-container description>{{ copy().sections.v2233.description }}</ng-container>
+
+    <ul class="list-disc pl-5 mt-4 space-y-2 text-sm font-light">
+      @for (item of copy().sections.v2233.items; track item) {
+        <li>{{ item }}</li>
+      }
+    </ul>
+
+    <div role="alert" class="alert alert-info alert-dash mt-4">
+      <i class="fa-solid fa-circle-info"></i>
+      <span>{{ copy().sections.v2233.upgrade }}</span>
+    </div>
+  </app-section-content>
+
+  <app-section-content class="block mt-10">
     <ng-container title>{{ copy().sections.v2231.title }}</ng-container>
     <ng-container description>{{ copy().sections.v2231.description }}</ng-container>
 

--- a/libs/ui/src/app/shared/components/pagination/pagination.html
+++ b/libs/ui/src/app/shared/components/pagination/pagination.html
@@ -1,5 +1,5 @@
 <div
-  class="flex justify-between items-center bg-base-200 dark:bg-base-100 gap-10 py-2 px-3"
+  class="flex justify-between items-center gap-10 bg-base-100"
   [class.flex-wrap]="isMobile"
   [class.gap-2!]="isMobile"
   [class.justify-center]="isMobile"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/ui",
-  "version": "22.3.2",
+  "version": "22.3.3",
   "scripts": {
     "build": "bun scripts/build",
     "build:doc": "bun run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/ui",
-  "version": "22.3.3",
+  "version": "22.3.4",
   "scripts": {
     "build": "bun scripts/build",
     "build:doc": "bun run build:docs",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -22,7 +22,6 @@ cpSync('libs/ui/src/app/shared/base', 'dist/ui/base', { recursive: true });
 cpSync('libs/ui/src/theme', 'dist/ui/theme', { recursive: true });
 cpSync('libs/ui/public/assets/icons', 'dist/ui/assets/icons', { recursive: true });
 cpSync('libs/ui/src/app/app.ts', 'dist/ui/app.ts');
-cpSync('libs/ui/src/index.html', 'dist/ui/index.html');
 
 cpSync('libs/ui/src/styles.css', 'dist/ui/styles.css');
 const styles = readFileSync('dist/ui/styles.css', 'utf-8');

--- a/scripts/generate-llms.js
+++ b/scripts/generate-llms.js
@@ -203,6 +203,17 @@ Changelog for anyone using or upgrading projects scaffolded with the Koala UI CL
 Site page: https://ui.koalarx.com/#/getting-started/patch-notes
 Root CHANGELOG.md mirrors these notes.
 
+## 22.3.3 — No docs leakage in the CLI
+
+### What changed
+
+- \`kl new\` uses a consumer \`index.html\` (no docs version/locale migration script).
+- \`kl install auth\` no longer depends on \`LocaleService\` / docs i18n.
+
+### Upgrade
+
+On existing projects: remove the hash/version migration \`<script>\` from \`src/index.html\`. If you use auth, reinstall with \`kl install auth\` (or drop \`../i18n/locale.service\` imports from the copied core files).
+
 ## 22.3.1 — CLI --silent
 
 ### What changed


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication redirect/navigation paths used by `kl install auth`, so incorrect routing could break login redirects in consumer apps. Scope is otherwise a targeted decoupling plus scaffolding/docs updates.
> 
> **Overview**
> **Stops docs-only artifacts from leaking into consumer projects** via the CLI.
> 
> `kl new` now scaffolds from a dedicated consumer `index.html` template (no hash/locale migration script), and the package build no longer copies the docs `index.html` into `dist`.
> 
> **Auth installables no longer depend on docs i18n.** `AuthorizationService` and `RouteAccessGuard` drop `LocaleService` and navigate with plain paths (`/${LOGIN_ROUTE}`, `/`), while still stripping optional `/pt`/`/en` prefixes when running on the docs site.
> 
> Documents the **22.3.3** upgrade path (strip the migration script; reinstall auth if needed) and bumps the package to **22.3.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ab924a3f44d9067c1fc6c050f7194c956fe04c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->