### PR TITLE
feat: 23.1.0 — CLI, Signal Forms, pagination, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ Formato inspirado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/)
 
 A partir de **23.x**, o major de `@koalarx/ui` = major do Angular + 1 (`23` → Angular 22). A linha `22.x` permanece para Angular 21 (`previous-release` / dist-tag `angular-21`).
 
+## [23.1.0] — CLI app/library/SSR, Signal Forms, pagination
+
+### Added
+
+- `kl new`: prompts app vs library e SSR; flags `--type`, `--ssr` / `--no-ssr`; AI context perguntado antes do scaffold.
+- Docs do `generate-icons` nativo (Resources).
+- Build da CLI no formato koala-nest (`Bun.Transpiler`, `bin` → `./cli/index.js`).
+
+### Changed
+
+- Serviços root: `@Injectable({ providedIn: 'root' })` → `@Service()`.
+- Pagination: default limit `30`; query param canônico `limit` (lê `pageSize` legado).
+- Inline-filter desktop em Signal Forms.
+
+### Fixed
+
+- Currency mask (evento `input` + sync value→DOM).
+- Pagination: página ativa com `btn-primary`.
+- Mobile-picker: filtros da URL no init do model.
+- Seletor de versão das docs (labels estáveis; sync `DOCS_VERSIONS` na linha 22).
+
+### Upgrade
+
+1. Reinstale `currency` e `inline-filter` se já tiver cópias antigas.
+2. Pagination grava `limit` na URL (`pageSize` ainda é lido).
+3. CI/agentes: `kl new <name> --silent [--type app|library] [--ssr|--no-ssr]`.
+
 ## [23.0.3] — Sem vazamento de docs na CLI
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,18 +31,17 @@ bun add -g @koalarx/ui
 
 Creates a new Angular project with the Koala structure and dependencies already configured.
 
-During project creation, the CLI asks which package manager you want to use and optionally scaffolds AI context (Cursor / GitHub Copilot):
+Interactive prompts (before scaffold): package manager → app/library → SSR (app only) → AI context (Cursor / GitHub Copilot).
 
-- `bun`
-- `npm`
-- `yarn`
-- `pnpm`
+Package managers: `bun`, `npm`, `yarn`, `pnpm`.
 
-You can also skip the interactive prompts with `--pm`, `--ai-context`, and `--silent` (non-interactive defaults: bun + AI context none).
+Skip prompts with `--pm`, `--type app|library`, `--ssr` / `--no-ssr`, `--ai-context`, and `--silent` (non-interactive defaults: bun + app + no SSR + AI context none).
 
 ```bash
 kl new --name meu-projeto
 kl new --name my-project --pm npm
+kl new my-app --ssr
+kl new my-lib --type library
 kl new my-app --ai-context both
 kl new my-app --silent
 ```

--- a/libs/cli/assets/ai-context/.github/copilot-instructions.md
+++ b/libs/cli/assets/ai-context/.github/copilot-instructions.md
@@ -15,8 +15,8 @@ Useful entry points: [Get Started](https://ui.koalarx.com/docs/get-started.md), 
 ## Hard constraints
 
 - Install missing pieces with `kl install <component[,component]> --silent`. Components land under `src/app/shared/components/`. Always pass `--silent` so external dependency prompts do not block the agent.
-- Prefer Signals, standalone components, and path aliases (`@/*` → `src/app/*`) from `kl new` / `kl init`. For non-interactive scaffolding use `kl new <name> --silent` (or `--pm` / `--ai-context`).
-- Prefer **Signal Forms** (`form()`, `[formField]`) for new forms. Installed controls implement `FormValueControl` / `FormCheckboxControl` and remain compatible with Reactive Forms on Angular 22.
+- Prefer Signals, standalone components, and path aliases (`@/*` → `src/app/*`) from `kl new` / `kl init`. For non-interactive scaffolding use `kl new <name> --silent` (or `--pm` / `--type` / `--ssr` / `--ai-context`).
+- Prefer **Signal Forms** (`form()`, `[formField]`) for new forms. Installed controls implement `FormValueControl` / `FormCheckboxControl` and remain compatible with Reactive Forms on Angular 22. Prefer `@Service()` for root services (Angular 22).
 - Base deps: `@koalarx/utils` ≥ 5 and `clsx`. Prefer documented Utils prototypes (e.g. `.orderBy()`).
 - Import installed UI from `@/shared/components/...` (or the local path already used in this repo). Follow existing `imports` arrays on standalone components.
 - Do not invent undocumented directives, inputs, or APIs — match docs and the sources already in this tree.

--- a/libs/cli/assets/ai-context/AGENTS.md
+++ b/libs/cli/assets/ai-context/AGENTS.md
@@ -15,8 +15,8 @@ Useful entry points: [Get Started](https://ui.koalarx.com/docs/get-started.md), 
 ## Hard constraints
 
 - Install missing pieces with `kl install <component[,component]> --silent`. Components land under `src/app/shared/components/`. Always pass `--silent` so external dependency prompts do not block the agent.
-- Prefer Signals, standalone components, and path aliases (`@/*` → `src/app/*`) from `kl new` / `kl init`. For non-interactive scaffolding use `kl new <name> --silent` (or `--pm` / `--ai-context`).
-- Prefer **Signal Forms** (`form()`, `[formField]`) for new forms. Installed controls implement `FormValueControl` / `FormCheckboxControl` and remain compatible with Reactive Forms on Angular 22.
+- Prefer Signals, standalone components, and path aliases (`@/*` → `src/app/*`) from `kl new` / `kl init`. For non-interactive scaffolding use `kl new <name> --silent` (or `--pm` / `--type` / `--ssr` / `--ai-context`).
+- Prefer **Signal Forms** (`form()`, `[formField]`) for new forms. Installed controls implement `FormValueControl` / `FormCheckboxControl` and remain compatible with Reactive Forms on Angular 22. Prefer `@Service()` for root services (Angular 22).
 - Base deps: `@koalarx/utils` ≥ 5 and `clsx`. Prefer documented Utils prototypes (e.g. `.orderBy()`).
 - Import installed UI from `@/shared/components/...` (or the local path already used in this repo). Follow existing `imports` arrays on standalone components.
 - Do not invent undocumented directives, inputs, or APIs — match docs and the sources already in this tree.

--- a/libs/cli/commands/install.ts
+++ b/libs/cli/commands/install.ts
@@ -1,6 +1,7 @@
 import { logHeader, logInstallSummary, logSuccess, logWarning } from '../utils/cli-ui';
 import { install } from '../utils/install';
-import { InstallComponentFlags, InstallComponentFlagsList } from '../utils/install-component';
+import { InstallComponentFlagsList } from '../utils/install-component';
+import type { InstallComponentFlags } from '../utils/install-component';
 import { detectPackageManager, getProjectExecCommand } from '../utils/package-manager';
 import { getProjectPath } from '../utils/project-path';
 import { runCommand } from '../utils/run-command';

--- a/libs/cli/commands/new.ts
+++ b/libs/cli/commands/new.ts
@@ -6,36 +6,37 @@ import {
   getAngularCreateCommand,
   getPmCommands,
   getProjectExecCommand,
-  PackageManager,
-  PmCommands,
 } from '../utils/package-manager';
+import type { PackageManager, PmCommands } from '../utils/package-manager';
 import { withVersions } from '../utils/dependency-versions';
 import { runCommand } from '../utils/run-command';
 import { setupGlobalTests } from '../utils/setup-global-tests';
 import { installUtil } from '../utils/install-util';
 import { applyAiContext, resolveAiContextTargets } from '../utils/apply-ai-context';
-
-const originPath = path.join(__dirname, '../../');
+import { askProjectType, askSsr, type ProjectType } from '../utils/prompt-project-options';
+import { getOriginPath } from '../utils/get-package-root';
 
 export interface NewArgs {
   name: string;
   pm?: PackageManager;
   verbose?: boolean;
   aiContext?: string;
-  /** Accept defaults without prompts (package manager + AI context). */
+  /** Accept defaults without prompts (package manager, type, SSR, AI context). */
   silent?: boolean;
+  type?: ProjectType;
+  ssr?: boolean;
 }
 
-async function createAngularProject(
+interface CreateProjectOptions {
+  type: ProjectType;
+  ssr: boolean;
+}
+
+async function installBaseDependencies(
   name: string,
-  pmName: PackageManager,
   pm: PmCommands,
   verbose = false,
 ): Promise<void> {
-  await runCommand(getAngularCreateCommand(name, pmName), {
-    verbose,
-    loaderText: `Creating project ${name}`,
-  });
   await runCommand(`${pm.install} ${withVersions(['@koalarx/utils', 'clsx']).join(' ')}`, {
     cwd: name,
     verbose,
@@ -56,32 +57,72 @@ async function createAngularProject(
       loaderText: 'Installing development dependencies',
     },
   );
+}
 
-  const angularJson = JSON.parse(readFileSync(`${name}/angular.json`, 'utf-8'));
-  angularJson.projects[name].architect.build.options.styles.push(
-    'src/theme/icons/font-awesome/css/all.min.css',
-  );
-  writeFileSync(`${name}/angular.json`, JSON.stringify(angularJson, null, 2));
-  cpSync(`${originPath}/ui/theme/icons`, `${name}/src/theme/icons`, { recursive: true });
-  cpSync(`${originPath}/ui/theme/grid.css`, `${name}/src/theme/grid.css`);
-  cpSync(`${originPath}/ui/generate-icons.js`, `${name}/generate-icons.js`);
+async function setupThemeAndIcons(name: string, verbose = false): Promise<void> {
+  mkdirSync(`${name}/public/assets/icons`, { recursive: true });
+  mkdirSync(`${name}/src/theme`, { recursive: true });
+  cpSync(`${getOriginPath()}/ui/theme/icons`, `${name}/src/theme/icons`, { recursive: true });
+  cpSync(`${getOriginPath()}/ui/theme/grid.css`, `${name}/src/theme/grid.css`);
+  cpSync(`${getOriginPath()}/ui/generate-icons.js`, `${name}/generate-icons.js`);
 
   await runCommand('node generate-icons.js', {
     cwd: name,
     verbose,
     loaderText: 'Generating icons',
   });
+}
 
-  const vscodeSettingsPath = `${originPath}/ui/.vscode/settings.json`;
+async function createAngularProject(
+  name: string,
+  pmName: PackageManager,
+  pm: PmCommands,
+  options: CreateProjectOptions,
+  verbose = false,
+): Promise<void> {
+  await runCommand(
+    getAngularCreateCommand(name, pmName, { type: options.type, ssr: options.ssr }),
+    {
+      verbose,
+      loaderText: `Creating project ${name}`,
+    },
+  );
+
+  await installBaseDependencies(name, pm, verbose);
+
+  if (options.type === 'app') {
+    const angularJson = JSON.parse(readFileSync(`${name}/angular.json`, 'utf-8'));
+    angularJson.projects[name].architect.build.options.styles.push(
+      'src/theme/icons/font-awesome/css/all.min.css',
+    );
+    writeFileSync(`${name}/angular.json`, JSON.stringify(angularJson, null, 2));
+  }
+
+  await setupThemeAndIcons(name, verbose);
+
+  const vscodeSettingsPath = `${getOriginPath()}/ui/.vscode/settings.json`;
   if (existsSync(vscodeSettingsPath)) {
+    mkdirSync(`${name}/.vscode`, { recursive: true });
     cpSync(vscodeSettingsPath, `${name}/.vscode/settings.json`);
   }
 }
 
-function createFolderStructure(name: string) {
+function updatePackageScripts(name: string) {
+  const packageJson = JSON.parse(readFileSync(`${name}/package.json`, 'utf-8'));
+  packageJson.scripts = {
+    ...packageJson.scripts,
+    prestart: 'node generate-icons.js',
+    prebuild: 'node generate-icons.js',
+    'build:dev': 'node generate-icons.js && ng build --configuration development',
+    'build:prod': 'node generate-icons.js && ng build --configuration production',
+  };
+  writeFileSync(`${name}/package.json`, JSON.stringify(packageJson, null, 2));
+}
+
+function createAppFolderStructure(name: string) {
   rmSync(`${name}/src/app/app.css`);
 
-  const indexHtml = readFileSync(`${originPath}/cli/assets/templates/index.html`, 'utf-8');
+  const indexHtml = readFileSync(`${getOriginPath()}/cli/assets/templates/index.html`, 'utf-8');
   writeFileSync(`${name}/src/index.html`, indexHtml.replaceAll('__PROJECT_NAME__', name));
 
   const appTs = readFileSync(`${name}/src/app/app.ts`, 'utf-8');
@@ -90,7 +131,7 @@ function createFolderStructure(name: string) {
     appTs.replace("styleUrl: './app.css',", '').replace("styleUrl: './app.css'", ''),
   );
 
-  const styles = readFileSync(`${originPath}/ui/styles.css`, 'utf-8');
+  const styles = readFileSync(`${getOriginPath()}/ui/styles.css`, 'utf-8');
   writeFileSync(`${name}/src/styles.css`, styles);
 
   const tsConfig = JSON.parse(
@@ -116,21 +157,41 @@ function createFolderStructure(name: string) {
   tsConfigSpec.include = ['src/**/*.d.ts', 'src/**/*.spec.ts'];
   writeFileSync(`${name}/tsconfig.spec.json`, JSON.stringify(tsConfigSpec, null, 2));
 
-  cpSync(`${originPath}/ui/eslint.config.mts`, `${name}/eslint.config.mts`);
-
-  const packageJson = JSON.parse(readFileSync(`${name}/package.json`, 'utf-8'));
-  packageJson.scripts = {
-    ...packageJson.scripts,
-    prestart: 'node generate-icons.js',
-    prebuild: 'node generate-icons.js',
-    'build:dev': 'node generate-icons.js && ng build --configuration development',
-    'build:prod': 'node generate-icons.js && ng build --configuration production',
-  };
-  writeFileSync(`${name}/package.json`, JSON.stringify(packageJson, null, 2));
+  cpSync(`${getOriginPath()}/ui/eslint.config.mts`, `${name}/eslint.config.mts`);
+  updatePackageScripts(name);
 
   mkdirSync(`${name}/src/app/shared`, { recursive: true });
-  mkdirSync(`${name}/public/assets/icons`, { recursive: true });
   logSuccess(console.log, `${name}/src/app/shared created`);
+}
+
+function createLibraryFolderStructure(name: string) {
+  const sharedRoot = `projects/${name}/src/lib/shared`;
+
+  writeFileSync(
+    `${name}/koala.json`,
+    JSON.stringify({ projectType: 'library', sharedRoot }, null, 2),
+  );
+
+  mkdirSync(`${name}/${sharedRoot}`, { recursive: true });
+  logSuccess(console.log, `${name}/${sharedRoot} created`);
+
+  const tsConfig = JSON.parse(
+    readFileSync(`${name}/tsconfig.json`, 'utf-8').replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, ''),
+  );
+  tsConfig.compilerOptions.paths = { '@/*': [`./projects/${name}/src/lib/*`] };
+  writeFileSync(`${name}/tsconfig.json`, JSON.stringify(tsConfig, null, 2));
+
+  cpSync(`${getOriginPath()}/ui/eslint.config.mts`, `${name}/eslint.config.mts`);
+  updatePackageScripts(name);
+}
+
+function createFolderStructure(name: string, projectType: ProjectType) {
+  if (projectType === 'library') {
+    createLibraryFolderStructure(name);
+    return;
+  }
+
+  createAppFolderStructure(name);
 }
 
 export async function runNewCommand(args: NewArgs): Promise<void> {
@@ -145,22 +206,48 @@ export async function runNewCommand(args: NewArgs): Promise<void> {
   const pmName = args.pm ?? (silent ? 'bun' : await askPackageManager());
   const pm = getPmCommands(pmName);
 
+  const projectType = args.type ?? (silent ? 'app' : await askProjectType());
+
+  let ssr = false;
+  if (projectType === 'app') {
+    if (args.ssr !== undefined) {
+      ssr = args.ssr;
+    } else if (!silent) {
+      ssr = await askSsr();
+    }
+  }
+
+  const aiContextFlag = args.aiContext ?? (silent ? 'none' : undefined);
+  const aiContextTargets = await resolveAiContextTargets(aiContextFlag);
+
   logHeader(console.log, 'KOALA UI PROJECT SETUP', `Project: ${name}`);
 
-  await createAngularProject(name, pmName, pm, verbose);
+  await createAngularProject(name, pmName, pm, { type: projectType, ssr }, verbose);
   logSuccess(console.log, 'Angular project created');
 
-  createFolderStructure(name);
+  if (projectType === 'library') {
+    await runCommand(getProjectExecCommand(pmName, `ng generate library ${name}`), {
+      cwd: name,
+      verbose,
+      loaderText: `Generating library ${name}`,
+    });
+    logSuccess(console.log, 'Angular library generated');
+  }
+
+  createFolderStructure(name, projectType);
   logSuccess(console.log, 'Koala structure applied');
 
-  await setupGlobalTests(name, verbose);
-  logSuccess(console.log, 'Test stack configured');
+  if (projectType === 'app') {
+    await setupGlobalTests(name, verbose);
+    logSuccess(console.log, 'Test stack configured');
 
-  await runCommand(getProjectExecCommand(pmName, 'ng generate environments'), {
-    cwd: name,
-    verbose,
-    loaderText: 'Generating environment files',
-  });
+    await runCommand(getProjectExecCommand(pmName, 'ng generate environments'), {
+      cwd: name,
+      verbose,
+      loaderText: 'Generating environment files',
+    });
+  }
+
   await runCommand(getProjectExecCommand(pmName, 'eslint . --fix'), {
     cwd: name,
     verbose,
@@ -172,11 +259,6 @@ export async function runNewCommand(args: NewArgs): Promise<void> {
     loaderText: 'Formatting project',
   });
 
-  installUtil(name, 'control-changes');
-  installUtil(name, 'form-is-valid');
-
-  const aiContextFlag = args.aiContext ?? (silent ? 'none' : undefined);
-  const aiContextTargets = await resolveAiContextTargets(aiContextFlag);
   applyAiContext(name, aiContextTargets);
 
   logSuccess(console.log, 'Project ready');

--- a/libs/cli/commands/new.ts
+++ b/libs/cli/commands/new.ts
@@ -166,13 +166,33 @@ function createAppFolderStructure(name: string) {
 
 function createLibraryFolderStructure(name: string) {
   const sharedRoot = `projects/${name}/src/lib/shared`;
+  const coreRoot = `projects/${name}/src/lib/core`;
+  const stylesPath = `projects/${name}/src/styles.css`;
+  const themeRoot = `projects/${name}/src/theme`;
 
   writeFileSync(
     `${name}/koala.json`,
-    JSON.stringify({ projectType: 'library', sharedRoot }, null, 2),
+    JSON.stringify(
+      {
+        projectType: 'library',
+        sharedRoot,
+        coreRoot,
+        stylesPath,
+        themeRoot,
+        appConfigPath: null,
+      },
+      null,
+      2,
+    ),
   );
 
   mkdirSync(`${name}/${sharedRoot}`, { recursive: true });
+  mkdirSync(`${name}/${coreRoot}`, { recursive: true });
+  mkdirSync(`${name}/${themeRoot}`, { recursive: true });
+
+  const styles = readFileSync(`${getOriginPath()}/ui/styles.css`, 'utf-8');
+  writeFileSync(`${name}/${stylesPath}`, styles);
+
   logSuccess(console.log, `${name}/${sharedRoot} created`);
 
   const tsConfig = JSON.parse(

--- a/libs/cli/index.ts
+++ b/libs/cli/index.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env bun
+
+import { runCli } from './runner';
+
+runCli(process.argv.slice(2))
+  .then((code) => process.exit(code ?? 0))
+  .catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });

--- a/libs/cli/models/install-result.ts
+++ b/libs/cli/models/install-result.ts
@@ -1,9 +1,9 @@
-import { InstallBaseFlags } from '../utils/install-base';
-import { InstallComponentFlags } from '../utils/install-component';
-import { InstallCoreResourceFlags } from '../utils/install-core-resource';
-import { InstallDirectiveFlags } from '../utils/install-directive';
-import { InstallUtilFlags } from '../utils/install-util';
-import { InstallValidatorFlags } from '../utils/install-validator';
+import type { InstallBaseFlags } from '../utils/install-base';
+import type { InstallComponentFlags } from '../utils/install-component';
+import type { InstallCoreResourceFlags } from '../utils/install-core-resource';
+import type { InstallDirectiveFlags } from '../utils/install-directive';
+import type { InstallUtilFlags } from '../utils/install-util';
+import type { InstallValidatorFlags } from '../utils/install-validator';
 
 export interface InstallResult {
   components: InstallComponentFlags[];

--- a/libs/cli/runner.ts
+++ b/libs/cli/runner.ts
@@ -1,15 +1,15 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { getPackageRoot } from './utils/get-package-root';
 import { runAddCommand } from './commands/add';
 import { runInstallCommand } from './commands/install';
 import { runInitCommand } from './commands/init';
 import { runNewCommand } from './commands/new';
-import { PackageManager } from './utils/package-manager';
+import type { PackageManager } from './utils/package-manager';
 
 function getCliVersion(): string {
   try {
-    // runner.js lives in `<packageRoot>/cli/` (published) or `<packageRoot>/dist/cli/` (local build)
-    const packageJsonPath = path.resolve(__dirname, '../package.json');
+    const packageJsonPath = path.join(getPackageRoot(import.meta.url), 'package.json');
     const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
     const packageJson = JSON.parse(packageJsonContent) as { version?: string };
 
@@ -83,7 +83,7 @@ function printHelp() {
   printBanner();
   console.log('Usage:');
   console.log(
-    '  kl new <project> [--pm bun|npm|yarn|pnpm] [--ai-context none|cursor|github|both] [--silent] [--verbose]',
+    '  kl new <project> [--pm bun|npm|yarn|pnpm] [--type app|library] [--ssr|--no-ssr] [--ai-context none|cursor|github|both] [--silent] [--verbose]',
   );
   console.log(
     '  kl init [--project <name>] [--ai-context none|cursor|github|both] [--silent] [--verbose]',
@@ -165,19 +165,22 @@ function printAddHelp() {
 
 function printNewHelp() {
   console.log(
-    'Usage: kl new <project> [--pm bun|npm|yarn|pnpm] [--ai-context none|cursor|github|both] [--silent] [--verbose]',
+    'Usage: kl new <project> [--pm bun|npm|yarn|pnpm] [--type app|library] [--ssr|--no-ssr] [--ai-context none|cursor|github|both] [--silent] [--verbose]',
   );
   console.log(
-    '       kl new --name <project> [--pm bun|npm|yarn|pnpm] [--ai-context none|cursor|github|both] [--silent] [--verbose]',
+    '       kl new --name <project> [--pm bun|npm|yarn|pnpm] [--type app|library] [--ssr|--no-ssr] [--ai-context none|cursor|github|both] [--silent] [--verbose]',
   );
   console.log('');
   console.log('FLAGS');
   console.log('  -m, --pm=<value>         package manager: bun|npm|yarn|pnpm');
+  console.log('      --type=<value>       project type: app|library (default: app)');
+  console.log('      --ssr                enable SSR (app only; default: disabled)');
+  console.log('      --no-ssr             disable SSR (app only)');
   console.log(
     '      --ai-context=<value>  none|cursor|github|both (skips interactive prompt)',
   );
   console.log(
-    '      --silent              non-interactive: bun + AI context none unless overridden',
+    '      --silent              non-interactive: bun + app + no SSR + AI context none unless overridden',
   );
   console.log('  -v, --verbose            show detailed logs');
 }
@@ -207,7 +210,14 @@ export async function runCli(argv: string[]): Promise<number> {
       const verbose = hasFlag(args, 'verbose', 'v');
       const silent = hasFlag(args, 'silent');
       const aiContext = getFlagValue(args, 'ai-context');
-      await runNewCommand({ name: name ?? '', pm, verbose, aiContext, silent });
+      const type = getFlagValue(args, 'type') as 'app' | 'library' | undefined;
+      let ssr: boolean | undefined;
+      if (hasFlag(args, 'ssr')) {
+        ssr = true;
+      } else if (hasFlag(args, 'no-ssr')) {
+        ssr = false;
+      }
+      await runNewCommand({ name: name ?? '', pm, verbose, aiContext, silent, type, ssr });
       return 0;
     }
 

--- a/libs/cli/runner.unit.spec.ts
+++ b/libs/cli/runner.unit.spec.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 
 vi.mock('node:fs');
+vi.mock('./utils/get-package-root', () => ({
+  getPackageRoot: vi.fn(() => '/fake/package/root'),
+}));
 vi.mock('./commands/init', () => ({
   runInitCommand: vi.fn(),
 }));
@@ -68,6 +71,8 @@ describe('CLI Runner', () => {
       verbose: false,
       aiContext: 'none',
       silent: false,
+      type: undefined,
+      ssr: undefined,
     });
   });
 
@@ -81,6 +86,38 @@ describe('CLI Runner', () => {
       verbose: false,
       aiContext: undefined,
       silent: true,
+      type: undefined,
+      ssr: undefined,
+    });
+  });
+
+  it('should pass --type and --ssr to new', async () => {
+    const result = await runCli(['new', 'demo', '--type', 'app', '--ssr']);
+
+    expect(result).toBe(0);
+    expect(runNewCommand).toHaveBeenCalledWith({
+      name: 'demo',
+      pm: undefined,
+      verbose: false,
+      aiContext: undefined,
+      silent: false,
+      type: 'app',
+      ssr: true,
+    });
+  });
+
+  it('should pass --no-ssr to new', async () => {
+    const result = await runCli(['new', 'demo', '--no-ssr']);
+
+    expect(result).toBe(0);
+    expect(runNewCommand).toHaveBeenCalledWith({
+      name: 'demo',
+      pm: undefined,
+      verbose: false,
+      aiContext: undefined,
+      silent: false,
+      type: undefined,
+      ssr: false,
     });
   });
 

--- a/libs/cli/tsconfig.json
+++ b/libs/cli/tsconfig.json
@@ -1,17 +1,17 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/cli",
-    "rootDir": "./",
-    "module": "node16",
-    "moduleResolution": "node16",
-    "target": "ES2020",
-    "lib": [
-      "ES2020"
-    ]
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "baseUrl": ".",
+    "paths": {
+      "@cli/*": ["./*"]
+    }
   },
-  "exclude": [
-    "**/*.unit.spec.ts",
-    "**/*.spec.ts"
-  ]
+  "include": ["**/*.ts"]
 }

--- a/libs/cli/utils/ensure-styles-import.ts
+++ b/libs/cli/utils/ensure-styles-import.ts
@@ -1,8 +1,9 @@
 import { readFileSync, writeFileSync } from 'node:fs';
+import { getProjectLayout } from './get-shared-root';
 
-/** Ensures `src/styles.css` imports `./theme/<name>.css` (idempotent). */
+/** Ensures styles.css imports `./theme/<name>.css` (idempotent). */
 export function ensureStylesImport(projectFolder: string, themeCssName: string) {
-  const stylesPath = `${projectFolder}/src/styles.css`;
+  const { stylesPath } = getProjectLayout(projectFolder);
   const stylesContent = readFileSync(stylesPath).toString('utf-8');
   const importStatement = `@import './theme/${themeCssName}.css';\n`;
 

--- a/libs/cli/utils/get-ai-context-assets-path.ts
+++ b/libs/cli/utils/get-ai-context-assets-path.ts
@@ -1,12 +1,20 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
+import { getPackageRoot } from './get-package-root';
 
 /** Pasta com AGENTS.md, .cursor/rules e .github para projetos gerados. */
 export function getAiContextAssetsPath(): string {
-  const publishedAssets = path.join(__dirname, '..', 'assets', 'ai-context');
+  const root = getPackageRoot(import.meta.url);
+  const publishedAssets = path.join(root, 'cli', 'assets', 'ai-context');
 
   if (existsSync(publishedAssets)) {
     return publishedAssets;
+  }
+
+  const monorepoAssets = path.join(root, 'libs', 'cli', 'assets', 'ai-context');
+
+  if (existsSync(monorepoAssets)) {
+    return monorepoAssets;
   }
 
   throw new Error('Assets de contexto AI não encontrados (cli/assets/ai-context).');

--- a/libs/cli/utils/get-not-installed.ts
+++ b/libs/cli/utils/get-not-installed.ts
@@ -7,7 +7,7 @@ import type { InstallDirectiveFlags } from './install-directive';
 import type { InstallUtilFlags } from './install-util';
 import type { InstallValidatorFlags } from './install-validator';
 import { getProjectPath } from './project-path';
-import { getSharedRoot } from './get-shared-root';
+import { getProjectLayout, getSharedRoot } from './get-shared-root';
 
 export type PackageType =
   | 'component'
@@ -122,9 +122,10 @@ export function getNotInstalled(projectName: string, type: PackageType, deps: st
     }
     case 'core-resource': {
       const projectFolder = getProjectPath(projectName);
+      const { coreRoot } = getProjectLayout(projectFolder);
 
       for (const dep of deps) {
-        if (!existsSync(`${projectFolder}/src/app/core/${dep}`)) {
+        if (!existsSync(`${coreRoot}/${dep}`)) {
           notInstalled.push(dep);
         }
       }
@@ -132,9 +133,10 @@ export function getNotInstalled(projectName: string, type: PackageType, deps: st
     }
     case 'css': {
       const projectFolder = getProjectPath(projectName);
+      const { themeRoot } = getProjectLayout(projectFolder);
 
       for (const dep of deps) {
-        if (!existsSync(`${projectFolder}/src/theme/${dep}`)) {
+        if (!existsSync(`${themeRoot}/${dep}`)) {
           notInstalled.push(dep);
         }
       }

--- a/libs/cli/utils/get-not-installed.ts
+++ b/libs/cli/utils/get-not-installed.ts
@@ -1,12 +1,13 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { InstallBaseFlags } from './install-base';
-import { InstallComponentFlags } from './install-component';
-import { InstallCoreResourceFlags } from './install-core-resource';
-import { InstallCssFlags } from './install-css';
-import { InstallDirectiveFlags } from './install-directive';
-import { InstallUtilFlags } from './install-util';
-import { InstallValidatorFlags } from './install-validator';
+import type { InstallBaseFlags } from './install-base';
+import type { InstallComponentFlags } from './install-component';
+import type { InstallCoreResourceFlags } from './install-core-resource';
+import type { InstallCssFlags } from './install-css';
+import type { InstallDirectiveFlags } from './install-directive';
+import type { InstallUtilFlags } from './install-util';
+import type { InstallValidatorFlags } from './install-validator';
 import { getProjectPath } from './project-path';
+import { getSharedRoot } from './get-shared-root';
 
 export type PackageType =
   | 'component'
@@ -64,43 +65,37 @@ export function getNotInstalled(projectName: string, type: 'lib', deps: string[]
 
 export function getNotInstalled(projectName: string, type: PackageType, deps: string[]): string[] {
   const notInstalled: string[] = [];
+  const projectFolder = getProjectPath(projectName);
+  const sharedRoot = getSharedRoot(projectFolder);
 
   switch (type) {
     case 'component': {
-      const projectFolder = getProjectPath(projectName);
-
       for (const dep of deps) {
-        if (!existsSync(`${projectFolder}/src/app/shared/components/${dep}`)) {
+        if (!existsSync(`${sharedRoot}/components/${dep}`)) {
           notInstalled.push(dep);
         }
       }
       break;
     }
     case 'directives': {
-      const projectFolder = getProjectPath(projectName);
-
       for (const dep of deps) {
-        if (!existsSync(`${projectFolder}/src/app/shared/directives/${dep}.directive.ts`)) {
+        if (!existsSync(`${sharedRoot}/directives/${dep}.directive.ts`)) {
           notInstalled.push(dep);
         }
       }
       break;
     }
     case 'validator': {
-      const projectFolder = getProjectPath(projectName);
-
       for (const dep of deps) {
-        if (!existsSync(`${projectFolder}/src/app/shared/validators/${dep}.validator.ts`)) {
+        if (!existsSync(`${sharedRoot}/validators/${dep}.validator.ts`)) {
           notInstalled.push(dep);
         }
       }
       break;
     }
     case 'utils': {
-      const projectFolder = getProjectPath(projectName);
-
       for (const dep of deps) {
-        if (!existsSync(`${projectFolder}/src/app/shared/utils/${dep}.ts`)) {
+        if (!existsSync(`${sharedRoot}/utils/${dep}.ts`)) {
           notInstalled.push(dep);
         }
       }
@@ -118,10 +113,8 @@ export function getNotInstalled(projectName: string, type: PackageType, deps: st
       break;
     }
     case 'base': {
-      const projectFolder = getProjectPath(projectName);
-
       for (const dep of deps) {
-        if (!existsSync(`${projectFolder}/src/app/shared/base/${dep}`)) {
+        if (!existsSync(`${sharedRoot}/base/${dep}`)) {
           notInstalled.push(dep);
         }
       }

--- a/libs/cli/utils/get-package-root.ts
+++ b/libs/cli/utils/get-package-root.ts
@@ -1,0 +1,50 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function isPublishRoot(dir: string): boolean {
+  return (
+    existsSync(path.join(dir, 'package.json')) &&
+    existsSync(path.join(dir, 'ui')) &&
+    existsSync(path.join(dir, 'cli'))
+  );
+}
+
+function isPackageRoot(dir: string): boolean {
+  if (!existsSync(path.join(dir, 'package.json'))) {
+    return false;
+  }
+
+  return (
+    existsSync(path.join(dir, 'ui')) ||
+    existsSync(path.join(dir, 'libs', 'ui'))
+  );
+}
+
+export function getPackageRoot(fromUrl: string = import.meta.url): string {
+  let dir = path.dirname(fileURLToPath(fromUrl));
+  let packageRoot: string | undefined;
+
+  while (dir !== path.dirname(dir)) {
+    if (isPublishRoot(dir)) {
+      return dir;
+    }
+
+    if (isPackageRoot(dir)) {
+      packageRoot = dir;
+    }
+
+    dir = path.dirname(dir);
+  }
+
+  if (packageRoot) {
+    return packageRoot;
+  }
+
+  throw new Error('Não foi possível resolver a raiz do pacote koala-ui.');
+}
+
+/** Directory containing `ui/` and `cli/` (published root or local `dist/`). */
+export function getOriginPath(fromUrl: string = import.meta.url): string {
+  return getPackageRoot(fromUrl);
+}

--- a/libs/cli/utils/get-package-root.unit.spec.ts
+++ b/libs/cli/utils/get-package-root.unit.spec.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getPackageRoot } from './get-package-root';
+
+describe('getPackageRoot', () => {
+  let tempDir = '';
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = '';
+    }
+  });
+
+  function probeFrom(relativeDir: string) {
+    const dir = path.join(tempDir, relativeDir);
+    mkdirSync(dir, { recursive: true });
+    return new URL(`file://${path.join(dir, 'probe.js')}`).href;
+  }
+
+  it('resolve pacote publicado com ui e cli na raiz', () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'koala-ui-root-'));
+    mkdirSync(path.join(tempDir, 'ui'), { recursive: true });
+    mkdirSync(path.join(tempDir, 'cli'), { recursive: true });
+    writeFileSync(
+      path.join(tempDir, 'package.json'),
+      `${JSON.stringify({ name: '@koalarx/ui', version: '1.0.0' }, null, 2)}\n`,
+    );
+
+    expect(getPackageRoot(probeFrom('cli/utils'))).toBe(tempDir);
+  });
+
+  it('resolve build local com ui e cli em dist', () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'koala-ui-root-'));
+    mkdirSync(path.join(tempDir, 'dist', 'ui'), { recursive: true });
+    mkdirSync(path.join(tempDir, 'dist', 'cli'), { recursive: true });
+    mkdirSync(path.join(tempDir, 'libs', 'ui'), { recursive: true });
+    writeFileSync(
+      path.join(tempDir, 'package.json'),
+      `${JSON.stringify({ name: '@koalarx/ui', version: '1.0.0' }, null, 2)}\n`,
+    );
+    writeFileSync(
+      path.join(tempDir, 'dist', 'package.json'),
+      `${JSON.stringify({ name: '@koalarx/ui', version: '1.0.0' }, null, 2)}\n`,
+    );
+
+    expect(getPackageRoot(probeFrom('dist/cli/utils'))).toBe(path.join(tempDir, 'dist'));
+  });
+
+  it('resolve monorepo com libs/ui', () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'koala-ui-root-'));
+    mkdirSync(path.join(tempDir, 'libs', 'ui'), { recursive: true });
+    writeFileSync(
+      path.join(tempDir, 'package.json'),
+      `${JSON.stringify({ name: '@koalarx/ui', version: '1.0.0' }, null, 2)}\n`,
+    );
+
+    expect(getPackageRoot(probeFrom('libs/cli/utils'))).toBe(tempDir);
+  });
+});

--- a/libs/cli/utils/get-shared-root.ts
+++ b/libs/cli/utils/get-shared-root.ts
@@ -1,0 +1,23 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+interface KoalaConfig {
+  sharedRoot?: string;
+}
+
+export function getSharedRoot(projectFolder: string): string {
+  const koalaJsonPath = path.join(projectFolder, 'koala.json');
+
+  if (existsSync(koalaJsonPath)) {
+    try {
+      const config = JSON.parse(readFileSync(koalaJsonPath, 'utf-8')) as KoalaConfig;
+      if (config.sharedRoot) {
+        return path.join(projectFolder, config.sharedRoot);
+      }
+    } catch {
+      // fall through to default
+    }
+  }
+
+  return path.join(projectFolder, 'src/app/shared');
+}

--- a/libs/cli/utils/get-shared-root.ts
+++ b/libs/cli/utils/get-shared-root.ts
@@ -3,21 +3,76 @@ import path from 'node:path';
 
 interface KoalaConfig {
   sharedRoot?: string;
+  coreRoot?: string;
+  stylesPath?: string;
+  themeRoot?: string;
+  appConfigPath?: string | null;
 }
 
-export function getSharedRoot(projectFolder: string): string {
-  const koalaJsonPath = path.join(projectFolder, 'koala.json');
+export interface ProjectLayout {
+  /** Absolute path to shared/ (components, utils, …). */
+  sharedRoot: string;
+  /** Absolute path to core/ (guards, interceptors, …). */
+  coreRoot: string;
+  /** Absolute path to the main styles.css. */
+  stylesPath: string;
+  /** Absolute path to theme/ CSS folder. */
+  themeRoot: string;
+  /**
+   * Absolute path to app.config.ts when the project has an application.
+   * `null` for library-only workspaces (skip app.config wiring).
+   */
+  appConfigPath: string | null;
+}
 
-  if (existsSync(koalaJsonPath)) {
-    try {
-      const config = JSON.parse(readFileSync(koalaJsonPath, 'utf-8')) as KoalaConfig;
-      if (config.sharedRoot) {
-        return path.join(projectFolder, config.sharedRoot);
-      }
-    } catch {
-      // fall through to default
-    }
+function readKoalaConfig(projectFolder: string): KoalaConfig {
+  const koalaJsonPath = path.join(projectFolder, 'koala.json');
+  if (!existsSync(koalaJsonPath)) {
+    return {};
   }
 
-  return path.join(projectFolder, 'src/app/shared');
+  try {
+    return JSON.parse(readFileSync(koalaJsonPath, 'utf-8')) as KoalaConfig;
+  } catch {
+    return {};
+  }
+}
+
+function resolveOptional(
+  projectFolder: string,
+  relativeOrNull: string | null | undefined,
+  fallback: string,
+): string {
+  if (relativeOrNull == null || relativeOrNull === '') {
+    return path.join(projectFolder, fallback);
+  }
+  return path.isAbsolute(relativeOrNull)
+    ? relativeOrNull
+    : path.join(projectFolder, relativeOrNull);
+}
+
+export function getProjectLayout(projectFolder: string): ProjectLayout {
+  const config = readKoalaConfig(projectFolder);
+
+  const sharedRoot = resolveOptional(projectFolder, config.sharedRoot, 'src/app/shared');
+  const coreRoot = resolveOptional(projectFolder, config.coreRoot, 'src/app/core');
+  const stylesPath = resolveOptional(projectFolder, config.stylesPath, 'src/styles.css');
+  const themeRoot = resolveOptional(projectFolder, config.themeRoot, 'src/theme');
+
+  let appConfigPath: string | null;
+  if (config.appConfigPath === null) {
+    appConfigPath = null;
+  } else if (config.appConfigPath) {
+    appConfigPath = resolveOptional(projectFolder, config.appConfigPath, 'src/app/app.config.ts');
+  } else {
+    const defaultAppConfig = path.join(projectFolder, 'src/app/app.config.ts');
+    appConfigPath = existsSync(defaultAppConfig) ? defaultAppConfig : null;
+  }
+
+  return { sharedRoot, coreRoot, stylesPath, themeRoot, appConfigPath };
+}
+
+/** @deprecated Prefer getProjectLayout().sharedRoot */
+export function getSharedRoot(projectFolder: string): string {
+  return getProjectLayout(projectFolder).sharedRoot;
 }

--- a/libs/cli/utils/install-base.ts
+++ b/libs/cli/utils/install-base.ts
@@ -1,17 +1,17 @@
 import { cpSync } from 'node:fs';
 import path from 'node:path';
+import { getOriginPath } from './get-package-root';
 import { getProjectPath } from './project-path';
-
-const originPath = path.join(__dirname, '../../');
-
+import { getSharedRoot } from './get-shared-root';
 export const InstallBaseFlagsList = ['list', 'http', 'page'] as const;
 export type InstallBaseFlags = (typeof InstallBaseFlagsList)[number];
 
 export function installBase(projectName: string, base: InstallBaseFlags) {
   const projectFolder = getProjectPath(projectName);
+  const sharedRoot = getSharedRoot(projectFolder);
 
   cpSync(
-    `${originPath}/ui/base/${base}.base.ts`,
-    `${projectFolder}/src/app/shared/base/${base}.base.ts`,
+    `${getOriginPath()}/ui/base/${base}.base.ts`,
+    `${sharedRoot}/base/${base}.base.ts`,
   );
 }

--- a/libs/cli/utils/install-base.unit.spec.ts
+++ b/libs/cli/utils/install-base.unit.spec.ts
@@ -5,6 +5,10 @@ import { installBase } from './install-base';
 
 vi.mock('node:fs');
 vi.mock('node:path');
+vi.mock('./get-package-root', () => ({
+  getOriginPath: () => '/fake/origin',
+  getPackageRoot: () => '/fake/origin',
+}));
 vi.mock('./project-path', () => ({
   getProjectPath: (name: string) => `/home/user/${name}`,
 }));

--- a/libs/cli/utils/install-component.ts
+++ b/libs/cli/utils/install-component.ts
@@ -1,16 +1,16 @@
 import { cpSync, existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { getOriginPath } from './get-package-root';
 import { getPrefix } from './get-prefix';
 import { getProjectPath } from './project-path';
-import { InstallValidatorFlags } from './install-validator';
-import { InstallDirectiveFlags } from './install-directive';
-import { InstallUtilFlags } from './install-util';
-import { InstallBaseFlags } from './install-base';
-import { InstallCoreResourceFlags } from './install-core-resource';
-import { InstallCssFlags } from './install-css';
-import { InstallIconSetFlags } from './install-icon';
-
-const originPath = path.join(__dirname, '../../');
+import { getSharedRoot } from './get-shared-root';
+import type { InstallValidatorFlags } from './install-validator';
+import type { InstallDirectiveFlags } from './install-directive';
+import type { InstallUtilFlags } from './install-util';
+import type { InstallBaseFlags } from './install-base';
+import type { InstallCoreResourceFlags } from './install-core-resource';
+import type { InstallCssFlags } from './install-css';
+import type { InstallIconSetFlags } from './install-icon';
 
 export const InstallComponentFlagsList = [
   'button',
@@ -87,8 +87,9 @@ function configPrefix(componentFolderPath: string, prefix: string) {
 export function installComponent(projectName: string, component: InstallComponentFlags) {
   const prefix = getPrefix(projectName);
   const projectFolder = getProjectPath(projectName);
-  const componentFolderPath = `${projectFolder}/src/app/shared/components/${component}`;
-  const componentOriginPath = `${originPath}/ui/components/${component}`;
+  const sharedRoot = getSharedRoot(projectFolder);
+  const componentFolderPath = `${sharedRoot}/components/${component}`;
+  const componentOriginPath = `${getOriginPath()}/ui/components/${component}`;
 
   const componentDeps: InstallComponentFlags[] = [];
   const libDeps: string[] = [];
@@ -113,7 +114,6 @@ export function installComponent(projectName: string, component: InstallComponen
       libDeps.push('cally');
       componentDeps.push('input-field', 'dropdown');
       directiveDeps.push('mask');
-      utilDeps.push('control-changes');
       break;
     case 'input-cpf':
     case 'input-cnpj':
@@ -138,14 +138,11 @@ export function installComponent(projectName: string, component: InstallComponen
       utilDeps.push(
         'scroll-into-view',
         'accessibility-select-options-on-keydown',
-        'control-changes',
       );
       componentDeps.push('dropdown', 'input-field', 'loading');
       break;
     case 'inline-filter':
       utilDeps.push(
-        'form-is-valid',
-        'control-changes',
         'is-mobile',
         'scroll-into-view',
         'accessibility-select-options-on-keydown',
@@ -231,7 +228,6 @@ export function installComponent(projectName: string, component: InstallComponen
         'ngx-tiptap',
       );
       componentDeps.push('dropdown', 'tooltip', 'input-color');
-      utilDeps.push('control-changes');
       cssDeps.push('editor');
       iconSetDeps.push('text-editor-icons');
       break;

--- a/libs/cli/utils/install-component.unit.spec.ts
+++ b/libs/cli/utils/install-component.unit.spec.ts
@@ -5,6 +5,10 @@ import { installComponent } from './install-component';
 
 vi.mock('node:fs');
 vi.mock('node:path');
+vi.mock('./get-package-root', () => ({
+  getOriginPath: () => '/fake/origin',
+  getPackageRoot: () => '/fake/origin',
+}));
 vi.mock('./get-prefix', () => ({
   getPrefix: () => 'app',
 }));
@@ -73,7 +77,7 @@ describe('installComponent', () => {
       'ngx-tiptap',
     ]);
     expect(deps.componentDeps).toEqual(['dropdown', 'tooltip', 'input-color']);
-    expect(deps.utilDeps).toEqual(['control-changes']);
+    expect(deps.utilDeps).toEqual([]);
     expect(deps.cssDeps).toEqual(['editor']);
     expect(deps.iconSetDeps).toEqual(['text-editor-icons']);
   });

--- a/libs/cli/utils/install-core-resource.ts
+++ b/libs/cli/utils/install-core-resource.ts
@@ -1,6 +1,7 @@
-import { cpSync, readFileSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { getOriginPath } from './get-package-root';
+import { getProjectLayout } from './get-shared-root';
 import { getProjectPath } from './project-path';
 
 export const InstallCoreResourceFlagsList = [
@@ -61,7 +62,11 @@ function includeOnAppConfig(
   resource: keyof typeof INTERCEPTOR_META,
 ) {
   const projectFolder = getProjectPath(projectName);
-  const appConfigPath = path.join(projectFolder, 'src/app/app.config.ts');
+  const { appConfigPath } = getProjectLayout(projectFolder);
+  if (!appConfigPath || !existsSync(appConfigPath)) {
+    return;
+  }
+
   let content = readFileSync(appConfigPath, 'utf-8');
   const { symbol, importPath } = INTERCEPTOR_META[resource];
 
@@ -96,7 +101,8 @@ function includeOnAppConfig(
 
 export function installCoreResource(projectName: string, resource: InstallCoreResourceFlags) {
   const projectFolder = getProjectPath(projectName);
-  const coreResourceFolderPath = `${projectFolder}/src/app/core/${resource}`;
+  const { coreRoot } = getProjectLayout(projectFolder);
+  const coreResourceFolderPath = path.join(coreRoot, resource);
   const coreResourceOriginPath = `${getOriginPath()}/ui/core/${resource}`;
 
   cpSync(`${coreResourceOriginPath}.ts`, `${coreResourceFolderPath}.ts`);

--- a/libs/cli/utils/install-core-resource.ts
+++ b/libs/cli/utils/install-core-resource.ts
@@ -1,8 +1,7 @@
 import { cpSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { getOriginPath } from './get-package-root';
 import { getProjectPath } from './project-path';
-
-const originPath = path.join(__dirname, '../../');
 
 export const InstallCoreResourceFlagsList = [
   'constants/security-storage-keys',
@@ -98,7 +97,7 @@ function includeOnAppConfig(
 export function installCoreResource(projectName: string, resource: InstallCoreResourceFlags) {
   const projectFolder = getProjectPath(projectName);
   const coreResourceFolderPath = `${projectFolder}/src/app/core/${resource}`;
-  const coreResourceOriginPath = `${originPath}/ui/core/${resource}`;
+  const coreResourceOriginPath = `${getOriginPath()}/ui/core/${resource}`;
 
   cpSync(`${coreResourceOriginPath}.ts`, `${coreResourceFolderPath}.ts`);
 

--- a/libs/cli/utils/install-core-resource.unit.spec.ts
+++ b/libs/cli/utils/install-core-resource.unit.spec.ts
@@ -25,6 +25,9 @@ describe('installCoreResource', () => {
   it('should copy feedback-request-interceptor and update app.config', () => {
     vi.mocked(fs.cpSync).mockImplementation(() => {});
     vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+    vi.mocked(fs.existsSync).mockImplementation(
+      (path) => String(path).endsWith('src/app/app.config.ts'),
+    );
 
     installCoreResource('my-app', 'interceptors/feedback-request-interceptor');
 

--- a/libs/cli/utils/install-core-resource.unit.spec.ts
+++ b/libs/cli/utils/install-core-resource.unit.spec.ts
@@ -5,6 +5,10 @@ import { installCoreResource } from './install-core-resource';
 
 vi.mock('node:fs');
 vi.mock('node:path');
+vi.mock('./get-package-root', () => ({
+  getOriginPath: () => '/fake/origin',
+  getPackageRoot: () => '/fake/origin',
+}));
 vi.mock('./project-path', () => ({
   getProjectPath: (name: string) => `/home/user/${name}`,
 }));

--- a/libs/cli/utils/install-css.ts
+++ b/libs/cli/utils/install-css.ts
@@ -1,10 +1,8 @@
 import { cpSync } from 'node:fs';
 import path from 'node:path';
+import { getOriginPath } from './get-package-root';
 import { ensureStylesImport } from './ensure-styles-import';
 import { getProjectPath } from './project-path';
-
-const originPath = path.join(__dirname, '../../');
-
 export const InstallCssFlagsList = [
   'table',
   'toast',
@@ -17,7 +15,7 @@ export type InstallCssFlags = (typeof InstallCssFlagsList)[number];
 
 export function installCss(projectName: string, css: InstallCssFlags) {
   const projectFolder = getProjectPath(projectName);
-  const originUtilPath = `${originPath}/ui/theme/${css}.css`;
+  const originUtilPath = `${getOriginPath()}/ui/theme/${css}.css`;
   const targetFolder = `${projectFolder}/src/theme`;
 
   cpSync(originUtilPath, `${targetFolder}/${css}.css`);

--- a/libs/cli/utils/install-css.ts
+++ b/libs/cli/utils/install-css.ts
@@ -1,7 +1,7 @@
 import { cpSync } from 'node:fs';
-import path from 'node:path';
 import { getOriginPath } from './get-package-root';
 import { ensureStylesImport } from './ensure-styles-import';
+import { getProjectLayout } from './get-shared-root';
 import { getProjectPath } from './project-path';
 export const InstallCssFlagsList = [
   'table',
@@ -15,9 +15,9 @@ export type InstallCssFlags = (typeof InstallCssFlagsList)[number];
 
 export function installCss(projectName: string, css: InstallCssFlags) {
   const projectFolder = getProjectPath(projectName);
+  const { themeRoot } = getProjectLayout(projectFolder);
   const originUtilPath = `${getOriginPath()}/ui/theme/${css}.css`;
-  const targetFolder = `${projectFolder}/src/theme`;
 
-  cpSync(originUtilPath, `${targetFolder}/${css}.css`);
+  cpSync(originUtilPath, `${themeRoot}/${css}.css`);
   ensureStylesImport(projectFolder, css);
 }

--- a/libs/cli/utils/install-directive.ts
+++ b/libs/cli/utils/install-directive.ts
@@ -1,17 +1,17 @@
 import { cpSync } from 'node:fs';
 import path from 'node:path';
+import { getOriginPath } from './get-package-root';
 import { getProjectPath } from './project-path';
-
-const originPath = path.join(__dirname, '../../');
-
+import { getSharedRoot } from './get-shared-root';
 export const InstallDirectiveFlagsList = ['mask', 'currency'] as const;
 export type InstallDirectiveFlags = (typeof InstallDirectiveFlagsList)[number];
 
 export function installDirective(projectName: string, directive: InstallDirectiveFlags) {
   const projectFolder = getProjectPath(projectName);
+  const sharedRoot = getSharedRoot(projectFolder);
 
   cpSync(
-    `${originPath}/ui/directives/${directive}.directive.ts`,
-    `${projectFolder}/src/app/shared/directives/${directive}.directive.ts`,
+    `${getOriginPath()}/ui/directives/${directive}.directive.ts`,
+    `${sharedRoot}/directives/${directive}.directive.ts`,
   );
 }

--- a/libs/cli/utils/install-icon.ts
+++ b/libs/cli/utils/install-icon.ts
@@ -1,11 +1,9 @@
 import { cpSync, existsSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
+import { getOriginPath } from './get-package-root';
 import { ensureStylesImport } from './ensure-styles-import';
 import { getProjectPath } from './project-path';
 import { runCommand } from './run-command';
-
-const originPath = path.join(__dirname, '../../');
-
 export const TEXT_EDITOR_ICON_FILES = [
   'add-image',
   'add',
@@ -40,7 +38,7 @@ export async function installIconSet(
     iconSet === 'text-editor-icons' ? TEXT_EDITOR_ICON_FILES : ([] as readonly string[]);
 
   for (const icon of icons) {
-    const origin = `${originPath}/ui/assets/icons/${icon}.svg`;
+    const origin = `${getOriginPath()}/ui/assets/icons/${icon}.svg`;
     const target = `${targetFolder}/${icon}.svg`;
 
     if (existsSync(origin)) {
@@ -54,7 +52,7 @@ export async function installIconSet(
   }
 
   const generateIconsPath = `${projectFolder}/generate-icons.js`;
-  const originGenerateIconsPath = `${originPath}/ui/generate-icons.js`;
+  const originGenerateIconsPath = `${getOriginPath()}/ui/generate-icons.js`;
 
   if (!existsSync(generateIconsPath) && existsSync(originGenerateIconsPath)) {
     cpSync(originGenerateIconsPath, generateIconsPath);

--- a/libs/cli/utils/install-icon.ts
+++ b/libs/cli/utils/install-icon.ts
@@ -1,7 +1,7 @@
 import { cpSync, existsSync, mkdirSync } from 'node:fs';
-import path from 'node:path';
 import { getOriginPath } from './get-package-root';
 import { ensureStylesImport } from './ensure-styles-import';
+import { getProjectLayout } from './get-shared-root';
 import { getProjectPath } from './project-path';
 import { runCommand } from './run-command';
 export const TEXT_EDITOR_ICON_FILES = [
@@ -28,11 +28,12 @@ export async function installIconSet(
   iconSet: InstallIconSetFlags,
 ): Promise<string[]> {
   const projectFolder = getProjectPath(projectName);
+  const { themeRoot } = getProjectLayout(projectFolder);
   const targetFolder = `${projectFolder}/public/assets/icons`;
   const installed: string[] = [];
 
   mkdirSync(targetFolder, { recursive: true });
-  mkdirSync(`${projectFolder}/src/theme`, { recursive: true });
+  mkdirSync(themeRoot, { recursive: true });
 
   const icons =
     iconSet === 'text-editor-icons' ? TEXT_EDITOR_ICON_FILES : ([] as readonly string[]);
@@ -67,7 +68,7 @@ export async function installIconSet(
   }
 
   // Toolbar utilities live in icons.css; wire the import like installCss does for theme sheets.
-  if (existsSync(`${projectFolder}/src/theme/icons.css`)) {
+  if (existsSync(`${themeRoot}/icons.css`)) {
     ensureStylesImport(projectFolder, 'icons');
   }
 

--- a/libs/cli/utils/install-icon.unit.spec.ts
+++ b/libs/cli/utils/install-icon.unit.spec.ts
@@ -7,6 +7,10 @@ import { runCommand } from './run-command';
 
 vi.mock('node:fs');
 vi.mock('node:path');
+vi.mock('./get-package-root', () => ({
+  getOriginPath: () => '/fake/origin',
+  getPackageRoot: () => '/fake/origin',
+}));
 vi.mock('./project-path', () => ({
   getProjectPath: (name: string) => `/home/user/${name}`,
 }));

--- a/libs/cli/utils/install-util.ts
+++ b/libs/cli/utils/install-util.ts
@@ -1,8 +1,8 @@
 import { cpSync, existsSync } from 'node:fs';
 import path from 'node:path';
+import { getOriginPath } from './get-package-root';
 import { getProjectPath } from './project-path';
-
-const originPath = path.join(__dirname, '../../');
+import { getSharedRoot } from './get-shared-root';
 
 export const InstallUtilFlagsList = [
   'currency-mask',
@@ -22,9 +22,10 @@ export type InstallUtilFlags = (typeof InstallUtilFlagsList)[number];
 
 export function installUtil(projectName: string, util: InstallUtilFlags) {
   const projectFolder = getProjectPath(projectName);
-  const originUtilPath = `${originPath}/ui/utils/${util}.ts`;
-  const originSpecPath = `${originPath}/ui/utils/${util}.unit.spec.ts`;
-  const targetFolder = `${projectFolder}/src/app/shared/utils`;
+  const sharedRoot = getSharedRoot(projectFolder);
+  const originUtilPath = `${getOriginPath()}/ui/utils/${util}.ts`;
+  const originSpecPath = `${getOriginPath()}/ui/utils/${util}.unit.spec.ts`;
+  const targetFolder = `${sharedRoot}/utils`;
 
   cpSync(originUtilPath, `${targetFolder}/${util}.ts`);
 

--- a/libs/cli/utils/install-validator.ts
+++ b/libs/cli/utils/install-validator.ts
@@ -1,17 +1,17 @@
 import { cpSync } from 'node:fs';
 import path from 'node:path';
+import { getOriginPath } from './get-package-root';
 import { getProjectPath } from './project-path';
-
-const originPath = path.join(__dirname, '../../');
-
+import { getSharedRoot } from './get-shared-root';
 export const InstallValidatorFlagsList = ['cpf', 'cnpj'] as const;
 export type InstallValidatorFlags = (typeof InstallValidatorFlagsList)[number];
 
 export function installValidator(projectName: string, validator: InstallValidatorFlags) {
   const projectFolder = getProjectPath(projectName);
+  const sharedRoot = getSharedRoot(projectFolder);
 
   cpSync(
-    `${originPath}/ui/validators/${validator}.validator.ts`,
-    `${projectFolder}/src/app/shared/validators/${validator}.validator.ts`,
+    `${getOriginPath()}/ui/validators/${validator}.validator.ts`,
+    `${sharedRoot}/validators/${validator}.validator.ts`,
   );
 }

--- a/libs/cli/utils/install.ts
+++ b/libs/cli/utils/install.ts
@@ -1,15 +1,23 @@
-import { InstallResult } from '../models/install-result';
+import type { InstallResult } from '../models/install-result';
 import { getNotInstalled } from './get-not-installed';
-import { installBase, InstallBaseFlags } from './install-base';
-import { installComponent, InstallComponentFlags } from './install-component';
-import { installDirective, InstallDirectiveFlags } from './install-directive';
+import { installBase } from './install-base';
+import { installComponent } from './install-component';
+import { installDirective } from './install-directive';
 import { installLib } from './install-lib';
 import { setupComponentTests } from './setup-component-tests';
-import { installUtil, InstallUtilFlags } from './install-util';
-import { installValidator, InstallValidatorFlags } from './install-validator';
-import { installCoreResource, InstallCoreResourceFlags } from './install-core-resource';
-import { installCss, InstallCssFlags } from './install-css';
-import { installIconSet, InstallIconSetFlags } from './install-icon';
+import { installUtil } from './install-util';
+import { installValidator } from './install-validator';
+import { installCoreResource } from './install-core-resource';
+import { installCss } from './install-css';
+import { installIconSet } from './install-icon';
+import type { InstallBaseFlags } from './install-base';
+import type { InstallComponentFlags } from './install-component';
+import type { InstallDirectiveFlags } from './install-directive';
+import type { InstallUtilFlags } from './install-util';
+import type { InstallValidatorFlags } from './install-validator';
+import type { InstallCoreResourceFlags } from './install-core-resource';
+import type { InstallCssFlags } from './install-css';
+import type { InstallIconSetFlags } from './install-icon';
 
 export async function install(
   projectName: string,

--- a/libs/cli/utils/package-manager.ts
+++ b/libs/cli/utils/package-manager.ts
@@ -57,10 +57,26 @@ export function getPmCommands(pm: PackageManager): PmCommands {
   }
 }
 
-export function getAngularCreateCommand(projectName: string, pm: PackageManager) {
+export interface AngularCreateOptions {
+  ssr?: boolean;
+  type?: 'app' | 'library';
+}
+
+export function getAngularCreateCommand(
+  projectName: string,
+  pm: PackageManager,
+  options?: AngularCreateOptions,
+) {
   const commands = getPmCommands(pm);
   const cliVersion = DEPENDENCY_VERSIONS['@angular/cli'];
-  return `${commands.dlx} @angular/cli@${cliVersion} new ${projectName} --defaults --style=tailwind --package-manager ${pm}`;
+  const type = options?.type ?? 'app';
+
+  if (type === 'library') {
+    return `${commands.dlx} @angular/cli@${cliVersion} new ${projectName} --create-application=false --defaults --package-manager ${pm} --skip-git`;
+  }
+
+  const ssrFlag = options?.ssr ? '--ssr' : '--ssr=false';
+  return `${commands.dlx} @angular/cli@${cliVersion} new ${projectName} --defaults --style=tailwind --package-manager ${pm} ${ssrFlag}`;
 }
 
 export function getProjectExecCommand(pm: PackageManager, command: string) {

--- a/libs/cli/utils/package-manager.unit.spec.ts
+++ b/libs/cli/utils/package-manager.unit.spec.ts
@@ -73,11 +73,19 @@ describe('Package Manager Utils', () => {
   });
 
   describe('getAngularCreateCommand', () => {
-    it('should build npm angular create command', () => {
+    it('should build npm angular create command for app without SSR', () => {
       const cmd = getAngularCreateCommand('my-app', 'npm');
 
       expect(cmd).toBe(
-        'npx --yes @angular/cli@^22.0.6 new my-app --defaults --style=tailwind --package-manager npm',
+        'npx --yes @angular/cli@^22.0.6 new my-app --defaults --style=tailwind --package-manager npm --ssr=false',
+      );
+    });
+
+    it('should build npm angular create command for app with SSR', () => {
+      const cmd = getAngularCreateCommand('my-app', 'npm', { type: 'app', ssr: true });
+
+      expect(cmd).toBe(
+        'npx --yes @angular/cli@^22.0.6 new my-app --defaults --style=tailwind --package-manager npm --ssr',
       );
     });
 
@@ -85,7 +93,7 @@ describe('Package Manager Utils', () => {
       const cmd = getAngularCreateCommand('my-app', 'yarn');
 
       expect(cmd).toBe(
-        'yarn dlx @angular/cli@^22.0.6 new my-app --defaults --style=tailwind --package-manager yarn',
+        'yarn dlx @angular/cli@^22.0.6 new my-app --defaults --style=tailwind --package-manager yarn --ssr=false',
       );
     });
 
@@ -93,7 +101,15 @@ describe('Package Manager Utils', () => {
       const cmd = getAngularCreateCommand('my-app', 'bun');
 
       expect(cmd).toBe(
-        'bunx @angular/cli@^22.0.6 new my-app --defaults --style=tailwind --package-manager bun',
+        'bunx @angular/cli@^22.0.6 new my-app --defaults --style=tailwind --package-manager bun --ssr=false',
+      );
+    });
+
+    it('should build library workspace create command', () => {
+      const cmd = getAngularCreateCommand('my-lib', 'npm', { type: 'library' });
+
+      expect(cmd).toBe(
+        'npx --yes @angular/cli@^22.0.6 new my-lib --create-application=false --defaults --package-manager npm --skip-git',
       );
     });
   });

--- a/libs/cli/utils/prompt-project-options.ts
+++ b/libs/cli/utils/prompt-project-options.ts
@@ -1,0 +1,49 @@
+import chalk from 'chalk';
+import prompts from 'prompts';
+
+export type ProjectType = 'app' | 'library';
+
+export async function askProjectType(): Promise<ProjectType> {
+  const response = await prompts(
+    {
+      type: 'select',
+      name: 'type',
+      message: `${chalk.cyan('KoalaUI')} Select project type`,
+      hint: '- Use arrow keys and Enter',
+      choices: [
+        { title: 'Application', value: 'app' as const, description: 'Full Angular app with UI shell' },
+        {
+          title: 'Library',
+          value: 'library' as const,
+          description: 'Angular workspace + publishable library',
+        },
+      ],
+      initial: 0,
+    },
+    {
+      onCancel: () => {
+        throw new Error('KoalaUI: project type selection was cancelled.');
+      },
+    },
+  );
+
+  return response.type as ProjectType;
+}
+
+export async function askSsr(): Promise<boolean> {
+  const response = await prompts(
+    {
+      type: 'confirm',
+      name: 'ssr',
+      message: `${chalk.cyan('KoalaUI')} Enable SSR (Server-Side Rendering)?`,
+      initial: false,
+    },
+    {
+      onCancel: () => {
+        throw new Error('KoalaUI: SSR selection was cancelled.');
+      },
+    },
+  );
+
+  return response.ssr as boolean;
+}

--- a/libs/cli/utils/run-command.ts
+++ b/libs/cli/utils/run-command.ts
@@ -1,4 +1,5 @@
-import { SpawnOptions, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import type { SpawnOptions } from 'node:child_process';
 import chalk from 'chalk';
 
 export interface RunCommandOptions extends SpawnOptions {

--- a/libs/cli/utils/setup-existing-project.ts
+++ b/libs/cli/utils/setup-existing-project.ts
@@ -5,13 +5,13 @@ import { detectTestFramework } from './detect-test-framework';
 import { withVersion } from './dependency-versions';
 import { detectPackageManager, getPmCommands, getProjectExecCommand } from './package-manager';
 import { getProjectPath } from './project-path';
+import { getSharedRoot } from './get-shared-root';
 import { runCommand } from './run-command';
 import { setupGlobalTests } from './setup-global-tests';
 import { validateAngularProject } from './validate-project';
 import { installUtil } from './install-util';
 import { applyAiContext, resolveAiContextTargets } from './apply-ai-context';
-
-const originPath = path.join(__dirname, '../../');
+import { getOriginPath } from './get-package-root';
 const KOALARX_UTILS_MIN_MAJOR = 5;
 
 /** True when utils is missing or its declared major is below the required major. */
@@ -52,12 +52,12 @@ export async function setupExistingProject(
 
   // Create shared folder structure
   logStep(logger, 'Creating folder structure...');
-  const requiredDirs = ['src/app/shared', 'src/theme/icons'];
+  const sharedRoot = getSharedRoot(projectPath);
+  const requiredDirs = [sharedRoot, `${projectPath}/src/theme/icons`];
 
   for (const dir of requiredDirs) {
-    const fullPath = `${projectPath}/${dir}`;
-    if (!existsSync(fullPath)) {
-      mkdirSync(fullPath, { recursive: true });
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
     }
   }
 
@@ -66,7 +66,7 @@ export async function setupExistingProject(
   // Copy themes and icons if they do not exist
   logStep(logger, 'Configuring themes...');
   const themeIconsPath = `${projectPath}/src/theme/icons`;
-  const originIconsPath = `${originPath}/ui/theme/icons`;
+  const originIconsPath = `${getOriginPath()}/ui/theme/icons`;
 
   if (!existsSync(`${themeIconsPath}/font-awesome`)) {
     if (existsSync(originIconsPath)) {
@@ -81,7 +81,7 @@ export async function setupExistingProject(
 
   const gridPath = `${projectPath}/src/theme/grid.css`;
   if (!existsSync(gridPath)) {
-    const originGridPath = `${originPath}/ui/theme/grid.css`;
+    const originGridPath = `${getOriginPath()}/ui/theme/grid.css`;
     if (existsSync(originGridPath)) {
       try {
         cpSync(originGridPath, gridPath);
@@ -93,7 +93,7 @@ export async function setupExistingProject(
 
   const tablePath = `${projectPath}/src/theme/table.css`;
   if (!existsSync(tablePath)) {
-    const originTablePath = `${originPath}/ui/theme/table.css`;
+    const originTablePath = `${getOriginPath()}/ui/theme/table.css`;
     if (existsSync(originTablePath)) {
       try {
         cpSync(originTablePath, tablePath);
@@ -107,7 +107,7 @@ export async function setupExistingProject(
 
   const generateIconsPath = `${projectPath}/generate-icons.js`;
   if (!existsSync(generateIconsPath)) {
-    const originGenerateIconsPath = `${originPath}/ui/generate-icons.js`;
+    const originGenerateIconsPath = `${getOriginPath()}/ui/generate-icons.js`;
     if (existsSync(originGenerateIconsPath)) {
       try {
         cpSync(originGenerateIconsPath, generateIconsPath);
@@ -196,7 +196,7 @@ export async function setupExistingProject(
   logStep(logger, 'Checking linting configuration...');
   const eslintConfigPath = `${projectPath}/eslint.config.mts`;
   if (!existsSync(eslintConfigPath)) {
-    const originEslintPath = `${originPath}/ui/eslint.config.mts`;
+    const originEslintPath = `${getOriginPath()}/ui/eslint.config.mts`;
     if (existsSync(originEslintPath)) {
       try {
         cpSync(originEslintPath, eslintConfigPath);
@@ -213,7 +213,7 @@ export async function setupExistingProject(
   logStep(logger, 'Checking VS Code configuration...');
   const vscodeDir = `${projectPath}/.vscode`;
   const vscodeSettingsPath = `${vscodeDir}/settings.json`;
-  const originVscodeSettingsPath = `${originPath}/ui/.vscode/settings.json`;
+  const originVscodeSettingsPath = `${getOriginPath()}/ui/.vscode/settings.json`;
 
   if (!existsSync(vscodeSettingsPath) && existsSync(originVscodeSettingsPath)) {
     try {
@@ -227,8 +227,6 @@ export async function setupExistingProject(
     logSuccess(logger, 'VS Code already configured');
   }
 
-  installUtil(projectName, 'control-changes');
-  installUtil(projectName, 'form-is-valid');
 
   const pm = detectPackageManager(projectName);
 

--- a/libs/cli/utils/setup-existing-project.unit.spec.ts
+++ b/libs/cli/utils/setup-existing-project.unit.spec.ts
@@ -3,6 +3,10 @@ import { setupExistingProject } from './setup-existing-project';
 import * as fs from 'node:fs';
 
 vi.mock('node:fs');
+vi.mock('./get-package-root', () => ({
+  getOriginPath: () => '/fake/origin',
+  getPackageRoot: () => '/fake/origin',
+}));
 vi.mock('./project-path', () => ({
   getProjectPath: (name: string) => `/test/projects/${name}`,
 }));

--- a/libs/ui/public/docs/datatable.md
+++ b/libs/ui/public/docs/datatable.md
@@ -113,7 +113,7 @@ kl install inline-filter,table,pagination,skeleton,button,loading,list
 
 ```typescript
 import { Component, inject } from '@angular/core';
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { Observable } from 'rxjs/internal/Observable';
 import { map } from 'rxjs/internal/operators/map';
 import { KlArray } from '@koalarx/utils/KlArray';
@@ -137,7 +137,7 @@ interface User {
   eyeColor: string;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class UsersService extends HttpBase {
   constructor() {
     super('https://dummyjson.com', 'users');

--- a/libs/ui/public/docs/generate-icons.md
+++ b/libs/ui/public/docs/generate-icons.md
@@ -1,0 +1,49 @@
+# Generate Icons
+
+## Installation
+
+```bash
+# Already included by kl new / kl init
+node generate-icons.js
+```
+
+Regenerates `src/theme/icons.css` from `public/assets/icons/*.svg`.
+
+### Usage
+
+```html
+<i class="app-icon add-image"></i>
+```
+
+### Overview
+
+# Generate Icons
+
+The native `generate-icons.js` script (copied to the project root by `kl new` / `kl init`) turns SVG files into Tailwind v4 utilities.
+
+## How it works
+
+1. Reads every `*.svg` under `public/assets/icons/`.
+2. Writes `src/theme/icons.css` with one `@utility <file-name>` per icon. Each utility sets `mask-image` / `-webkit-mask-image` on `::after` pointing at `/assets/icons/<file>.svg`.
+3. The base `@utility app-icon` in `styles.css` provides size, alignment, and mask sizing. Icons are composed as `app-icon` + the generated utility name.
+4. `styles.css` must import `./theme/icons.css` (ensured by the CLI).
+
+The generated file starts with `/* Generated Automatically - Do not edit manually */`.
+
+## When it runs
+
+- `prestart`, `prebuild`, `build:dev`, and `build:prod` (`node generate-icons.js`)
+- After `kl install` of icon sets such as `text-editor-icons`
+- Manually: `node generate-icons.js` at the project root
+
+## Usage
+
+```html
+<i class="app-icon add-image"></i>
+```
+
+## Custom icons
+
+1. Add `public/assets/icons/my-icon.svg`
+2. Run `node generate-icons.js`
+3. Use `<i class="app-icon my-icon"></i>`

--- a/libs/ui/public/docs/get-started.md
+++ b/libs/ui/public/docs/get-started.md
@@ -34,18 +34,26 @@ kl new example
 # with custom package manager
 kl new example --pm pnpm
 
+# application with SSR
+kl new example --ssr
+
+# Angular library workspace
+kl new example --type library
+
 # skip AI context prompt
 kl new example --ai-context none
 
 # scaffold Cursor + Copilot context without prompting
 kl new example --ai-context both
 
-# non-interactive (AI agents / CI): bun + AI context none
+# non-interactive (AI agents / CI): bun + app + no SSR + AI context none
 kl new example --silent
 
 # non-interactive with overrides
-kl new example --silent --pm pnpm --ai-context both
+kl new example --silent --pm pnpm --type app --ssr --ai-context both
 ```
+
+Prompts (interactive, before scaffold): package manager → app/library → SSR (app only) → AI context.
 
 During setup you can scaffold AI context (Cursor / GitHub Copilot). Use `--ai-context none|cursor|github|both` to skip the prompt.
 For AI agents or CI, prefer `--silent` (non-interactive: bun + AI context none unless overridden).
@@ -125,3 +133,7 @@ kl add ai-context cursor github
 - **Global Errors** – `kl install -n global-errors`
 - **Rules** – `kl install -n rules`
 - **Auth** – `kl install -n auth`
+
+## Native tooling
+
+- **Generate Icons** – ships with `kl new` / `kl init` (`generate-icons.js`). Docs: [Generate Icons](https://ui.koalarx.com/#/resources/generate-icons).

--- a/libs/ui/public/docs/http-base.md
+++ b/libs/ui/public/docs/http-base.md
@@ -9,7 +9,7 @@ kl install http-base
 ### TypeScript
 
 ```typescript
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { HttpBase } from '@/shared/base/http.base';
 import { environment } from '@/environments/environment';
 
@@ -18,7 +18,7 @@ interface User {
   name: string;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class UsersService extends HttpBase {
   constructor() {
     super(environment.apiUrl, 'users');

--- a/libs/ui/public/docs/list-base.md
+++ b/libs/ui/public/docs/list-base.md
@@ -10,7 +10,7 @@ kl install list-base
 
 ```typescript
 import { Component } from '@angular/core';
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { Observable } from 'rxjs/internal/Observable';
 import { map } from 'rxjs/internal/operators/map';
 import { DatalistResponse, ListBase } from '@/shared/base/list.base';
@@ -23,7 +23,7 @@ interface User {
   email: string;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class UsersService extends HttpBase {
   constructor() {
     super(environment.apiUrl, 'users');

--- a/libs/ui/public/docs/pagination.md
+++ b/libs/ui/public/docs/pagination.md
@@ -9,11 +9,11 @@ kl install pagination
 ### HTML
 
 ```html
-<app-pagination class="w-full" size="xs" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="sm" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="md" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="lg" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="xl" [page]="1" [pageSize]="10" [total]="100" />
+<app-pagination class="w-full" size="xs" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="sm" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="md" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="lg" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="xl" [page]="1" [pageSize]="30" [total]="100" />
 ```
 
 ```typescript

--- a/libs/ui/public/docs/text-editor.md
+++ b/libs/ui/public/docs/text-editor.md
@@ -146,7 +146,7 @@ Reactive Forms still work via Angular 22 FormValueControl interop (`[formControl
 
 ```typescript
 import { HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { catchError, map, Observable, of } from 'rxjs';
 import { HttpBase } from '@/shared/base/http.base';
 import { TextEditorFileData, TextEditorFileService } from '@/shared/components/text-editor';
@@ -156,7 +156,7 @@ export enum FolderEnum {
   article = 1,
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class FileService extends HttpBase implements TextEditorFileService {
   constructor() {
     super(environment.apiUrl, 'file');

--- a/libs/ui/public/llms-full.txt
+++ b/libs/ui/public/llms-full.txt
@@ -36,18 +36,26 @@ kl new example
 # with custom package manager
 kl new example --pm pnpm
 
+# application with SSR
+kl new example --ssr
+
+# Angular library workspace
+kl new example --type library
+
 # skip AI context prompt
 kl new example --ai-context none
 
 # scaffold Cursor + Copilot context without prompting
 kl new example --ai-context both
 
-# non-interactive (AI agents / CI): bun + AI context none
+# non-interactive (AI agents / CI): bun + app + no SSR + AI context none
 kl new example --silent
 
 # non-interactive with overrides
-kl new example --silent --pm pnpm --ai-context both
+kl new example --silent --pm pnpm --type app --ssr --ai-context both
 ```
+
+Prompts (interactive, before scaffold): package manager → app/library → SSR (app only) → AI context.
 
 During setup you can scaffold AI context (Cursor / GitHub Copilot). Use `--ai-context none|cursor|github|both` to skip the prompt.
 For AI agents or CI, prefer `--silent` (non-interactive: bun + AI context none unless overridden).
@@ -127,6 +135,10 @@ kl add ai-context cursor github
 - **Global Errors** – `kl install -n global-errors`
 - **Rules** – `kl install -n rules`
 - **Auth** – `kl install -n auth`
+
+## Native tooling
+
+- **Generate Icons** – ships with `kl new` / `kl init` (`generate-icons.js`). Docs: [Generate Icons](https://ui.koalarx.com/#/resources/generate-icons).
 
 ---
 
@@ -1004,7 +1016,7 @@ kl install inline-filter,table,pagination,skeleton,button,loading,list
 
 ```typescript
 import { Component, inject } from '@angular/core';
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { Observable } from 'rxjs/internal/Observable';
 import { map } from 'rxjs/internal/operators/map';
 import { KlArray } from '@koalarx/utils/KlArray';
@@ -1028,7 +1040,7 @@ interface User {
   eyeColor: string;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class UsersService extends HttpBase {
   constructor() {
     super('https://dummyjson.com', 'users');
@@ -2144,11 +2156,11 @@ kl install pagination
 ### HTML
 
 ```html
-<app-pagination class="w-full" size="xs" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="sm" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="md" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="lg" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="xl" [page]="1" [pageSize]="10" [total]="100" />
+<app-pagination class="w-full" size="xs" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="sm" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="md" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="lg" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="xl" [page]="1" [pageSize]="30" [total]="100" />
 ```
 
 ```typescript
@@ -3253,7 +3265,7 @@ Reactive Forms still work via Angular 22 FormValueControl interop (`[formControl
 
 ```typescript
 import { HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { catchError, map, Observable, of } from 'rxjs';
 import { HttpBase } from '@/shared/base/http.base';
 import { TextEditorFileData, TextEditorFileService } from '@/shared/components/text-editor';
@@ -3263,7 +3275,7 @@ export enum FolderEnum {
   article = 1,
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class FileService extends HttpBase implements TextEditorFileService {
   constructor() {
     super(environment.apiUrl, 'file');
@@ -3613,7 +3625,7 @@ kl install list-base
 
 ```typescript
 import { Component } from '@angular/core';
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { Observable } from 'rxjs/internal/Observable';
 import { map } from 'rxjs/internal/operators/map';
 import { DatalistResponse, ListBase } from '@/shared/base/list.base';
@@ -3626,7 +3638,7 @@ interface User {
   email: string;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class UsersService extends HttpBase {
   constructor() {
     super(environment.apiUrl, 'users');
@@ -3717,7 +3729,7 @@ kl install http-base
 ### TypeScript
 
 ```typescript
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { HttpBase } from '@/shared/base/http.base';
 import { environment } from '@/environments/environment';
 
@@ -3726,7 +3738,7 @@ interface User {
   name: string;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class UsersService extends HttpBase {
   constructor() {
     super(environment.apiUrl, 'users');
@@ -3978,3 +3990,55 @@ This resource provides interceptor, guard and service for authentication in your
 ## Usage
 
 See usage examples in the [Login Block](./login.md).
+
+---
+
+# Generate Icons
+
+## Installation
+
+```bash
+# Already included by kl new / kl init
+node generate-icons.js
+```
+
+Regenerates `src/theme/icons.css` from `public/assets/icons/*.svg`.
+
+### Usage
+
+```html
+<i class="app-icon add-image"></i>
+```
+
+### Overview
+
+# Generate Icons
+
+The native `generate-icons.js` script (copied to the project root by `kl new` / `kl init`) turns SVG files into Tailwind v4 utilities.
+
+## How it works
+
+1. Reads every `*.svg` under `public/assets/icons/`.
+2. Writes `src/theme/icons.css` with one `@utility <file-name>` per icon. Each utility sets `mask-image` / `-webkit-mask-image` on `::after` pointing at `/assets/icons/<file>.svg`.
+3. The base `@utility app-icon` in `styles.css` provides size, alignment, and mask sizing. Icons are composed as `app-icon` + the generated utility name.
+4. `styles.css` must import `./theme/icons.css` (ensured by the CLI).
+
+The generated file starts with `/* Generated Automatically - Do not edit manually */`.
+
+## When it runs
+
+- `prestart`, `prebuild`, `build:dev`, and `build:prod` (`node generate-icons.js`)
+- After `kl install` of icon sets such as `text-editor-icons`
+- Manually: `node generate-icons.js` at the project root
+
+## Usage
+
+```html
+<i class="app-icon add-image"></i>
+```
+
+## Custom icons
+
+1. Add `public/assets/icons/my-icon.svg`
+2. Run `node generate-icons.js`
+3. Use `<i class="app-icon my-icon"></i>`

--- a/libs/ui/public/llms.txt
+++ b/libs/ui/public/llms.txt
@@ -49,6 +49,7 @@
 - [Global Errors](https://ui.koalarx.com/docs/global-errors.md): Global Errors component
 - [Rules](https://ui.koalarx.com/docs/rules.md): Rules component
 - [Auth](https://ui.koalarx.com/docs/auth.md): Auth component
+- [Generate Icons](https://ui.koalarx.com/docs/generate-icons.md): Generate Icons component
 
 ## CLI
 

--- a/libs/ui/public/markdown/install/create-project.md
+++ b/libs/ui/public/markdown/install/create-project.md
@@ -4,15 +4,23 @@ kl new example
 # with custom package manager
 kl new example --pm pnpm
 
+# application with SSR
+kl new example --ssr
+
+# Angular library workspace
+kl new example --type library
+
 # skip AI context prompt
 kl new example --ai-context none
 
 # scaffold Cursor + Copilot context without prompting
 kl new example --ai-context both
 
-# non-interactive (AI agents / CI): bun + AI context none
+# non-interactive (AI agents / CI): bun + app + no SSR + AI context none
 kl new example --silent
 
 # non-interactive with overrides
-kl new example --silent --pm pnpm --ai-context both
+kl new example --silent --pm pnpm --type app --ssr --ai-context both
 ```
+
+Prompts (interactive, before scaffold): package manager → app/library → SSR (app only) → AI context.

--- a/libs/ui/public/markdown/install/generate-icons-install.md
+++ b/libs/ui/public/markdown/install/generate-icons-install.md
@@ -1,0 +1,6 @@
+```bash
+# Already included by kl new / kl init
+node generate-icons.js
+```
+
+Regenerates `src/theme/icons.css` from `public/assets/icons/*.svg`.

--- a/libs/ui/public/markdown/usage/datatable/datatable.ts.md
+++ b/libs/ui/public/markdown/usage/datatable/datatable.ts.md
@@ -1,6 +1,6 @@
 ```typescript
 import { Component, inject } from '@angular/core';
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { Observable } from 'rxjs/internal/Observable';
 import { map } from 'rxjs/internal/operators/map';
 import { KlArray } from '@koalarx/utils/KlArray';
@@ -24,7 +24,7 @@ interface User {
   eyeColor: string;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class UsersService extends HttpBase {
   constructor() {
     super('https://dummyjson.com', 'users');

--- a/libs/ui/public/markdown/usage/generate-icons/overview.md
+++ b/libs/ui/public/markdown/usage/generate-icons/overview.md
@@ -1,0 +1,30 @@
+# Generate Icons
+
+The native `generate-icons.js` script (copied to the project root by `kl new` / `kl init`) turns SVG files into Tailwind v4 utilities.
+
+## How it works
+
+1. Reads every `*.svg` under `public/assets/icons/`.
+2. Writes `src/theme/icons.css` with one `@utility <file-name>` per icon. Each utility sets `mask-image` / `-webkit-mask-image` on `::after` pointing at `/assets/icons/<file>.svg`.
+3. The base `@utility app-icon` in `styles.css` provides size, alignment, and mask sizing. Icons are composed as `app-icon` + the generated utility name.
+4. `styles.css` must import `./theme/icons.css` (ensured by the CLI).
+
+The generated file starts with `/* Generated Automatically - Do not edit manually */`.
+
+## When it runs
+
+- `prestart`, `prebuild`, `build:dev`, and `build:prod` (`node generate-icons.js`)
+- After `kl install` of icon sets such as `text-editor-icons`
+- Manually: `node generate-icons.js` at the project root
+
+## Usage
+
+```html
+<i class="app-icon add-image"></i>
+```
+
+## Custom icons
+
+1. Add `public/assets/icons/my-icon.svg`
+2. Run `node generate-icons.js`
+3. Use `<i class="app-icon my-icon"></i>`

--- a/libs/ui/public/markdown/usage/generate-icons/usage.html.md
+++ b/libs/ui/public/markdown/usage/generate-icons/usage.html.md
@@ -1,0 +1,3 @@
+```html
+<i class="app-icon add-image"></i>
+```

--- a/libs/ui/public/markdown/usage/http-base/http-base.ts.md
+++ b/libs/ui/public/markdown/usage/http-base/http-base.ts.md
@@ -1,5 +1,5 @@
 ```typescript
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { HttpBase } from '@/shared/base/http.base';
 import { environment } from '@/environments/environment';
 
@@ -8,7 +8,7 @@ interface User {
   name: string;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class UsersService extends HttpBase {
   constructor() {
     super(environment.apiUrl, 'users');

--- a/libs/ui/public/markdown/usage/list-base/list-base.ts.md
+++ b/libs/ui/public/markdown/usage/list-base/list-base.ts.md
@@ -1,6 +1,6 @@
 ```typescript
 import { Component } from '@angular/core';
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { Observable } from 'rxjs/internal/Observable';
 import { map } from 'rxjs/internal/operators/map';
 import { DatalistResponse, ListBase } from '@/shared/base/list.base';
@@ -13,7 +13,7 @@ interface User {
   email: string;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class UsersService extends HttpBase {
   constructor() {
     super(environment.apiUrl, 'users');

--- a/libs/ui/public/markdown/usage/pagination/pagination.html.md
+++ b/libs/ui/public/markdown/usage/pagination/pagination.html.md
@@ -1,7 +1,7 @@
 ```html
-<app-pagination class="w-full" size="xs" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="sm" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="md" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="lg" [page]="1" [pageSize]="10" [total]="100" />
-<app-pagination class="w-full" size="xl" [page]="1" [pageSize]="10" [total]="100" />
+<app-pagination class="w-full" size="xs" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="sm" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="md" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="lg" [page]="1" [pageSize]="30" [total]="100" />
+<app-pagination class="w-full" size="xl" [page]="1" [pageSize]="30" [total]="100" />
 ```

--- a/libs/ui/public/markdown/usage/text-editor/text-editor-file-service.ts.md
+++ b/libs/ui/public/markdown/usage/text-editor/text-editor-file-service.ts.md
@@ -1,6 +1,6 @@
 ```typescript
 import { HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { catchError, map, Observable, of } from 'rxjs';
 import { HttpBase } from '@/shared/base/http.base';
 import { TextEditorFileData, TextEditorFileService } from '@/shared/components/text-editor';
@@ -10,7 +10,7 @@ export enum FolderEnum {
   article = 1,
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class FileService extends HttpBase implements TextEditorFileService {
   constructor() {
     super(environment.apiUrl, 'file');

--- a/libs/ui/public/search-index.json
+++ b/libs/ui/public/search-index.json
@@ -11,7 +11,7 @@
     "title": "Installation",
     "category": "Getting Started",
     "route": "getting-started/installation",
-    "content": "Koala UI – Get Started Koala UI is an Angular component library inspired by shadcn/ui. Components are installed directly into your project via the Koala CLI , giving you full control over the source code. Base dependencies installed by / : @koalarx/utils ≥ 5 and . Full utils API for LLMs: https://utils.koalarx.com/llms.txt. Version compatibility Two support lines (like Angular current + previous): Line Git branch Docs npm dist-tag ------ ------------ ------ -------------- Latest https://ui.koalarx.com/ Previous https://ui.koalarx.com/v{major}/ see release (e.g. for the 22.x line on Angular 21) Older majors are frozen on archive branches named by version (e.g. ) with no publish/deploy. 1. Install the CLI 2. Create a new project During setup you can scaffold AI context (Cursor / GitHub Copilot). Use to skip the prompt. For AI agents or CI, prefer (non-interactive: bun + AI context none unless overridden). 3. Add components Use to accept all external dependency installs without prompting (recommended for AI agents). 4. Add AI context (optional) 5. Add resources (optional) Available components - Alert – - Bottom Sheet – - Breadcrumb – - Button – - Calendar – - Checkbox – - Collapse – - Combobox – - Confirm – - DataTable – - Dropdown – - Fieldset – - Inline Filter – - Input CNPJ – - Input CPF – - Input Color – - Input Currency – - Input Field – - Loading – - Login – - Modal – - Pagination – - Radio – - Range – - Select – - Side Window – - Skeleton – - Stepper – - Table – - Tabs – - Textarea – - Text Editor – - Toast – - Toggle – - Tooltip – - Validator – - List Base – - Http Base – - Page Base – - Global Errors – - Rules – - Auth –"
+    "content": "Koala UI – Get Started Koala UI is an Angular component library inspired by shadcn/ui. Components are installed directly into your project via the Koala CLI , giving you full control over the source code. Base dependencies installed by / : @koalarx/utils ≥ 5 and . Full utils API for LLMs: https://utils.koalarx.com/llms.txt. Version compatibility Two support lines (like Angular current + previous): Line Git branch Docs npm dist-tag ------ ------------ ------ -------------- Latest https://ui.koalarx.com/ Previous https://ui.koalarx.com/v{major}/ see release (e.g. for the 22.x line on Angular 21) Older majors are frozen on archive branches named by version (e.g. ) with no publish/deploy. 1. Install the CLI 2. Create a new project Prompts (interactive, before scaffold): package manager → app/library → SSR (app only) → AI context. During setup you can scaffold AI context (Cursor / GitHub Copilot). Use to skip the prompt. For AI agents or CI, prefer (non-interactive: bun + AI context none unless overridden). 3. Add components Use to accept all external dependency installs without prompting (recommended for AI agents). 4. Add AI context (optional) 5. Add resources (optional) Available components - Alert – - Bottom Sheet – - Breadcrumb – - Button – - Calendar – - Checkbox – - Collapse – - Combobox – - Confirm – - DataTable – - Dropdown – - Fieldset – - Inline Filter – - Input CNPJ – - Input CPF – - Input Color – - Input Currency – - Input Field – - Loading – - Login – - Modal – - Pagination – - Radio – - Range – - Select – - Side Window – - Skeleton – - Stepper – - Table – - Tabs – - Textarea – - Text Editor – - Toast – - Toggle – - Tooltip – - Validator – - List Base – - Http Base – - Page Base – - Global Errors – - Rules – - Auth – Native tooling - Generate Icons – ships with / ( ). Docs: Generate Icons."
   },
   {
     "id": "getting-started/installation#version-compatibility",
@@ -35,7 +35,7 @@
     "category": "Getting Started",
     "route": "getting-started/installation",
     "fragment": "2-create-a-new-project",
-    "content": "During setup you can scaffold AI context (Cursor / GitHub Copilot). Use to skip the prompt. For AI agents or CI, prefer (non-interactive: bun + AI context none unless overridden)."
+    "content": "Prompts (interactive, before scaffold): package manager → app/library → SSR (app only) → AI context. During setup you can scaffold AI context (Cursor / GitHub Copilot). Use to skip the prompt. For AI agents or CI, prefer (non-interactive: bun + AI context none unless overridden)."
   },
   {
     "id": "getting-started/installation#3-add-components",
@@ -68,6 +68,14 @@
     "route": "getting-started/installation",
     "fragment": "available-components",
     "content": "- Alert – - Bottom Sheet – - Breadcrumb – - Button – - Calendar – - Checkbox – - Collapse – - Combobox – - Confirm – - DataTable – - Dropdown – - Fieldset – - Inline Filter – - Input CNPJ – - Input CPF – - Input Color – - Input Currency – - Input Field – - Loading – - Login – - Modal – - Pagination – - Radio – - Range – - Select – - Side Window – - Skeleton – - Stepper – - Table – - Tabs – - Textarea – - Text Editor – - Toast – - Toggle – - Tooltip – - Validator – - List Base – - Http Base – - Page Base – - Global Errors – - Rules – - Auth –"
+  },
+  {
+    "id": "getting-started/installation#native-tooling",
+    "title": "Native tooling",
+    "category": "Getting Started",
+    "route": "getting-started/installation",
+    "fragment": "native-tooling",
+    "content": "- Generate Icons – ships with / ( ). Docs: Generate Icons."
   },
   {
     "id": "getting-started/patch-notes",
@@ -1953,5 +1961,68 @@
     "route": "resources/auth",
     "fragment": "usage",
     "content": "See usage examples in the Login Block."
+  },
+  {
+    "id": "resources/generate-icons",
+    "title": "Generate Icons",
+    "category": "Resources",
+    "route": "resources/generate-icons",
+    "content": "Generate Icons Installation Regenerates from . Usage Overview Generate Icons The native script (copied to the project root by / ) turns SVG files into Tailwind v4 utilities. How it works 1. Reads every under . 2. Writes with one per icon. Each utility sets / on pointing at . 3. The base in provides size, alignment, and mask sizing. Icons are composed as + the generated utility name. 4. must import (ensured by the CLI). The generated file starts with . When it runs - , , , and ( ) - After of icon sets such as - Manually: at the project root Usage Custom icons 1. Add 2. Run 3. Use"
+  },
+  {
+    "id": "resources/generate-icons#installation",
+    "title": "Installation",
+    "category": "Resources",
+    "route": "resources/generate-icons",
+    "fragment": "installation",
+    "content": "Regenerates from ."
+  },
+  {
+    "id": "resources/generate-icons#usage",
+    "title": "Usage",
+    "category": "Resources",
+    "route": "resources/generate-icons",
+    "fragment": "usage",
+    "content": ""
+  },
+  {
+    "id": "resources/generate-icons#overview",
+    "title": "Overview",
+    "category": "Resources",
+    "route": "resources/generate-icons",
+    "fragment": "overview",
+    "content": "Generate Icons The native script (copied to the project root by / ) turns SVG files into Tailwind v4 utilities."
+  },
+  {
+    "id": "resources/generate-icons#how-it-works",
+    "title": "How it works",
+    "category": "Resources",
+    "route": "resources/generate-icons",
+    "fragment": "how-it-works",
+    "content": "1. Reads every under . 2. Writes with one per icon. Each utility sets / on pointing at . 3. The base in provides size, alignment, and mask sizing. Icons are composed as + the generated utility name. 4. must import (ensured by the CLI). The generated file starts with ."
+  },
+  {
+    "id": "resources/generate-icons#when-it-runs",
+    "title": "When it runs",
+    "category": "Resources",
+    "route": "resources/generate-icons",
+    "fragment": "when-it-runs",
+    "content": "- , , , and ( ) - After of icon sets such as - Manually: at the project root"
+  },
+  {
+    "id": "resources/generate-icons#usage-2",
+    "title": "Usage",
+    "category": "Resources",
+    "route": "resources/generate-icons",
+    "fragment": "usage-2",
+    "content": ""
+  },
+  {
+    "id": "resources/generate-icons#custom-icons",
+    "title": "Custom icons",
+    "category": "Resources",
+    "route": "resources/generate-icons",
+    "fragment": "custom-icons",
+    "content": "1. Add 2. Run 3. Use"
   }
 ]

--- a/libs/ui/src/app/core/components/doc-search/doc-search.service.ts
+++ b/libs/ui/src/app/core/components/doc-search/doc-search.service.ts
@@ -1,11 +1,11 @@
 import { HttpClient } from '@angular/common/http';
-import { inject, Injectable, signal } from '@angular/core';
+import { inject, Service, signal } from '@angular/core';
 import MiniSearch from 'minisearch';
 import { firstValueFrom } from 'rxjs';
 import { DocsVersionService } from '../../docs-version/docs-version.service';
 import { DocSearchEntry, DocSearchResult } from './doc-search.types';
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class DocSearchService {
   private readonly http = inject(HttpClient);
   private readonly docsVersion = inject(DocsVersionService);

--- a/libs/ui/src/app/core/components/header/header.ts
+++ b/libs/ui/src/app/core/components/header/header.ts
@@ -64,9 +64,12 @@ export class Header {
     return this.docsVersion.isCurrent(entry);
   }
 
-  /** Active line shows full semver; other lines keep the short major label. */
+  /** Active line shows full semver when it matches entry major; others keep short label. */
   docsVersionLabel(entry: DocsVersionEntry) {
-    return this.isDocsVersionCurrent(entry) ? this.appVersion : entry.label;
+    if (!this.isDocsVersionCurrent(entry)) {
+      return entry.label;
+    }
+    return this.appVersion.startsWith(`${entry.major}.`) ? this.appVersion : entry.label;
   }
 
   copyLlmsUrl() {

--- a/libs/ui/src/app/core/components/nav-menu/nav-menu.ts
+++ b/libs/ui/src/app/core/components/nav-menu/nav-menu.ts
@@ -144,6 +144,7 @@ export class NavMenu {
       {
         name: groups.others,
         items: new KlArray<MenuOption>([
+          { name: 'Generate Icons', routerLink: 'resources/generate-icons' },
           { name: 'Global Errors', routerLink: 'resources/global-errors' },
         ]).orderBy('name'),
       },

--- a/libs/ui/src/app/core/constants/app-version.ts
+++ b/libs/ui/src/app/core/constants/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '23.0.3';
+export const APP_VERSION = '23.1.0';

--- a/libs/ui/src/app/core/docs-version/docs-version.service.ts
+++ b/libs/ui/src/app/core/docs-version/docs-version.service.ts
@@ -1,5 +1,5 @@
 import { APP_BASE_HREF } from '@angular/common';
-import { inject, Injectable } from '@angular/core';
+import { inject, Service } from '@angular/core';
 import { DOCS_VERSIONS, type DocsVersionEntry } from '../constants/docs-versions';
 
 function normalizeBasePath(value: string): string {
@@ -15,7 +15,7 @@ function joinBase(basePath: string, relativePath: string): string {
   return `${base}${rel}`;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class DocsVersionService {
   private readonly injectedBase = inject(APP_BASE_HREF, { optional: true });
 

--- a/libs/ui/src/app/core/i18n/docs/pages/generate-icons.ts
+++ b/libs/ui/src/app/core/i18n/docs/pages/generate-icons.ts
@@ -1,0 +1,79 @@
+import type { Locale } from '../../locale.types';
+import type { DocPageCopy } from '../types';
+
+export const GENERATE_ICONS_PAGE = {
+  pt: {
+    title: 'Generate Icons',
+    description:
+      'O script nativo generate-icons.js gera classes Tailwind v4 a partir dos SVGs em public/assets/icons, para uso com a utility app-icon.',
+    sections: {
+      howItWorks: {
+        title: 'Como funciona',
+        description:
+          'No scaffold (kl new / kl init) o arquivo generate-icons.js fica na raiz do projeto. Ele lê public/assets/icons/*.svg e escreve src/theme/icons.css.',
+        items: [
+          'Para cada SVG, gera @utility <nome-do-arquivo> com mask-image no ::after.',
+          'A base @utility app-icon em styles.css define tamanho e máscara; o ícone combina app-icon + a utility gerada.',
+          'styles.css importa ./theme/icons.css (o CLI garante o import).',
+          'Não edite icons.css à mão — o arquivo é regenerado automaticamente.',
+        ],
+      },
+      whenItRuns: {
+        title: 'Quando roda',
+        description: 'O script entra nos scripts do package.json e em installs de icon sets.',
+        items: [
+          'prestart / prebuild / build:dev / build:prod (node generate-icons.js).',
+          'Após kl install de sets de ícones (ex.: text-editor-icons).',
+          'Manual: node generate-icons.js na raiz do projeto.',
+        ],
+      },
+      usage: {
+        title: 'Uso',
+        description: 'Use o nome do arquivo SVG (sem extensão) junto com app-icon.',
+      },
+      custom: {
+        title: 'Ícones customizados',
+        description:
+          'Coloque um SVG em public/assets/icons/<nome>.svg, rode node generate-icons.js e use class="app-icon <nome>".',
+      },
+    },
+  },
+  en: {
+    title: 'Generate Icons',
+    description:
+      'The native generate-icons.js script builds Tailwind v4 utilities from SVGs in public/assets/icons, for use with the app-icon utility.',
+    sections: {
+      howItWorks: {
+        title: 'How it works',
+        description:
+          'On scaffold (kl new / kl init) generate-icons.js is placed at the project root. It reads public/assets/icons/*.svg and writes src/theme/icons.css.',
+        items: [
+          'For each SVG, it emits @utility <file-name> with mask-image on ::after.',
+          'The base @utility app-icon in styles.css sets size and mask; icons combine app-icon + the generated utility.',
+          'styles.css imports ./theme/icons.css (CLI ensures the import).',
+          'Do not edit icons.css by hand — it is regenerated automatically.',
+        ],
+      },
+      whenItRuns: {
+        title: 'When it runs',
+        description: 'Wired into package.json scripts and icon-set installs.',
+        items: [
+          'prestart / prebuild / build:dev / build:prod (node generate-icons.js).',
+          'After kl install of icon sets (e.g. text-editor-icons).',
+          'Manual: node generate-icons.js at the project root.',
+        ],
+      },
+      usage: {
+        title: 'Usage',
+        description: 'Use the SVG file name (without extension) together with app-icon.',
+      },
+      custom: {
+        title: 'Custom icons',
+        description:
+          'Drop an SVG into public/assets/icons/<name>.svg, run node generate-icons.js, then use class="app-icon <name>".',
+      },
+    },
+  },
+} as const satisfies Record<Locale, DocPageCopy>;
+
+export type GenerateIconsPageCopy = (typeof GENERATE_ICONS_PAGE)[Locale];

--- a/libs/ui/src/app/core/i18n/docs/pages/index.ts
+++ b/libs/ui/src/app/core/i18n/docs/pages/index.ts
@@ -43,6 +43,7 @@ import { HTTP_BASE_PAGE } from './http-base';
 import { LIST_BASE_PAGE } from './list-base';
 import { PAGE_BASE_PAGE } from './page-base';
 import { RULES_PAGE } from './rules';
+import { GENERATE_ICONS_PAGE } from './generate-icons';
 import { PATCH_NOTES_PAGE } from './patch-notes';
 
 export { INSTALLATION_PAGE, type InstallationPageCopy } from './installation';
@@ -90,6 +91,7 @@ export { HTTP_BASE_PAGE, type HttpBasePageCopy } from './http-base';
 export { LIST_BASE_PAGE, type ListBasePageCopy } from './list-base';
 export { PAGE_BASE_PAGE, type PageBasePageCopy } from './page-base';
 export { RULES_PAGE, type RulesPageCopy } from './rules';
+export { GENERATE_ICONS_PAGE, type GenerateIconsPageCopy } from './generate-icons';
 
 export const DOCS_PAGES = {
   installation: INSTALLATION_PAGE,
@@ -137,6 +139,7 @@ export const DOCS_PAGES = {
   'list-base': LIST_BASE_PAGE,
   'page-base': PAGE_BASE_PAGE,
   rules: RULES_PAGE,
+  'generate-icons': GENERATE_ICONS_PAGE,
 } as const;
 
 export type DocsPageSlug = keyof typeof DOCS_PAGES;

--- a/libs/ui/src/app/core/i18n/docs/pages/patch-notes.ts
+++ b/libs/ui/src/app/core/i18n/docs/pages/patch-notes.ts
@@ -12,6 +12,23 @@ export const PATCH_NOTES_PAGE = {
         description:
           'A versão publicada do pacote @koalarx/ui aparece no package.json do repositório. O arquivo CHANGELOG.md na raiz espelha estas notas. A partir de 23.x, o major da lib = major do Angular + 1 (23 → Angular 22). Para Angular 21 use a linha 22.x; para Angular 22 use 23.x.',
       },
+      v2310: {
+        title: '23.1.0 — CLI app/library/SSR, Signal Forms, pagination',
+        description:
+          'Feature: scaffolding da CLI, inline-filter em Signal Forms, pagination e docs do generate-icons.',
+        items: [
+          'Currency mask: listener input + sync value→DOM (IME/autofill).',
+          'Pagination: página ativa btn-primary; queryParams page/limit; default limit 30.',
+          'Inline-filter desktop em Signal Forms; mobile-picker hidrata filtros da URL no init.',
+          'Serviços root usam @Service() (Angular 22).',
+          'kl new: prompts app|library + SSR; AI context antes do scaffold; flags --type / --ssr.',
+          'Build da CLI no formato koala-nest (Bun.Transpiler, bin ./cli/index.js).',
+          'Docs do generate-icons nativo (Resources).',
+          'Seletor de versão das docs: labels estáveis (companion na linha 22 sincroniza DOCS_VERSIONS).',
+        ],
+        upgrade:
+          'Reinstale currency e inline-filter se já tiver cópias antigas (kl install currency,inline-filter). Pagination passa a gravar limit na URL (pageSize legado ainda é lido). Em agentes/CI: kl new <name> --silent [--type app|library] [--ssr|--no-ssr].',
+      },
       v2303: {
         title: '23.0.3 — Sem vazamento de docs na CLI',
         description:
@@ -83,6 +100,23 @@ export const PATCH_NOTES_PAGE = {
         title: 'How to use these notes',
         description:
           'The published @koalarx/ui package version is in the repository package.json. The root CHANGELOG.md mirrors these notes. From 23.x onward, library major = Angular major + 1 (23 → Angular 22). For Angular 21 use the 22.x line; for Angular 22 use 23.x.',
+      },
+      v2310: {
+        title: '23.1.0 — CLI app/library/SSR, Signal Forms, pagination',
+        description:
+          'Feature: CLI scaffolding, inline-filter on Signal Forms, pagination, and generate-icons docs.',
+        items: [
+          'Currency mask: input listener + value→DOM sync (IME/autofill).',
+          'Pagination: active page btn-primary; queryParams page/limit; default limit 30.',
+          'Inline-filter desktop on Signal Forms; mobile-picker hydrates URL filters on init.',
+          'Root services use @Service() (Angular 22).',
+          'kl new: app|library + SSR prompts; AI context before scaffold; --type / --ssr flags.',
+          'CLI build aligned with koala-nest (Bun.Transpiler, bin ./cli/index.js).',
+          'Native generate-icons documentation (Resources).',
+          'Docs version switcher: stable labels (companion 22.x line syncs DOCS_VERSIONS).',
+        ],
+        upgrade:
+          'Reinstall currency and inline-filter if you already have older copies (kl install currency,inline-filter). Pagination now writes limit to the URL (legacy pageSize is still read). For agents/CI: kl new <name> --silent [--type app|library] [--ssr|--no-ssr].',
       },
       v2303: {
         title: '23.0.3 — No docs leakage in the CLI',

--- a/libs/ui/src/app/core/i18n/locale-title.service.ts
+++ b/libs/ui/src/app/core/i18n/locale-title.service.ts
@@ -1,5 +1,5 @@
 import { Title } from '@angular/platform-browser';
-import { effect, inject, Injectable } from '@angular/core';
+import { effect, inject, Injectable, Service } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router, TitleStrategy } from '@angular/router';
 import { filter, map, startWith } from 'rxjs';
@@ -9,7 +9,7 @@ import { LocaleService } from './locale.service';
 import { isLocale } from './locale.types';
 import { UI_COPY } from './ui-copy';
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class LocaleTitleService {
   private readonly router = inject(Router);
   private readonly title = inject(Title);

--- a/libs/ui/src/app/core/i18n/locale.service.ts
+++ b/libs/ui/src/app/core/i18n/locale.service.ts
@@ -1,10 +1,10 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Service } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { filter, map, startWith } from 'rxjs';
 import { DEFAULT_LOCALE, isLocale, type Locale, SUPPORTED_LOCALES } from './locale.types';
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class LocaleService {
   private readonly router = inject(Router);
 

--- a/libs/ui/src/app/core/security/authorization.service.ts
+++ b/libs/ui/src/app/core/security/authorization.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { computed, effect, inject, Injectable, signal } from '@angular/core';
+import { computed, effect, inject, Service, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { jwtDecode } from 'jwt-decode';
 import { tap } from 'rxjs/internal/operators/tap';
@@ -20,7 +20,7 @@ export interface AuthEvent {
   data: any;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class AuthorizationService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);

--- a/libs/ui/src/app/core/utils/http-error-feedback-alert.ts
+++ b/libs/ui/src/app/core/utils/http-error-feedback-alert.ts
@@ -1,9 +1,9 @@
 import { Toast } from '@/shared/components/toast';
 import { HttpErrorResponse } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
+import { inject, Service } from '@angular/core';
 import { HttpErrorMiddleware } from '../middlewares/http-errors.midleware';
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class HttpErrorFeedbackAlert {
   private readonly toast = inject(Toast);
 

--- a/libs/ui/src/app/features/blocks/datatable/users.service.ts
+++ b/libs/ui/src/app/features/blocks/datatable/users.service.ts
@@ -1,6 +1,6 @@
 import { HttpBase } from '@/shared/base/http.base';
 import { DatalistResponse } from '@/shared/base/list.base';
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { KlArray } from '@koalarx/utils/KlArray';
 import { Observable } from 'rxjs/internal/Observable';
 import { map } from 'rxjs/internal/operators/map';
@@ -25,7 +25,7 @@ interface UsersQueryParams {
   email?: string;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class UsersService extends HttpBase {
   constructor() {
     super('https://dummyjson.com', 'users');

--- a/libs/ui/src/app/features/components/pagination/pagination.page.html
+++ b/libs/ui/src/app/features/components/pagination/pagination.page.html
@@ -18,11 +18,11 @@
         <div
           class="flex flex-col items-center justify-center gap-2 p-4 sm:p-10 border border-t-0 border-base-300 rounded-b-lg"
         >
-          <app-pagination class="w-full" size="xs" [page]="1" [pageSize]="10" [total]="100" />
-          <app-pagination class="w-full" size="sm" [page]="1" [pageSize]="10" [total]="100" />
-          <app-pagination class="w-full" size="md" [page]="1" [pageSize]="10" [total]="100" />
-          <app-pagination class="w-full" size="lg" [page]="1" [pageSize]="10" [total]="100" />
-          <app-pagination class="w-full" size="xl" [page]="1" [pageSize]="10" [total]="100" />
+          <app-pagination class="w-full" size="xs" [page]="1" [pageSize]="30" [total]="100" />
+          <app-pagination class="w-full" size="sm" [page]="1" [pageSize]="30" [total]="100" />
+          <app-pagination class="w-full" size="md" [page]="1" [pageSize]="30" [total]="100" />
+          <app-pagination class="w-full" size="lg" [page]="1" [pageSize]="30" [total]="100" />
+          <app-pagination class="w-full" size="xl" [page]="1" [pageSize]="30" [total]="100" />
         </div>
       </div>
 

--- a/libs/ui/src/app/features/resources/generate-icons/generate-icons.page.html
+++ b/libs/ui/src/app/features/resources/generate-icons/generate-icons.page.html
@@ -1,0 +1,44 @@
+<app-section-container>
+  <ng-container title>{{ copy().title }}</ng-container>
+  <ng-container description>{{ copy().description }}</ng-container>
+
+  <app-section-content>
+    <ng-container title>{{ common().installation }}</ng-container>
+    <app-code-viewer language="bash" name="kl" src="markdown/install/generate-icons-install.md" />
+  </app-section-content>
+
+  <app-section-content>
+    <ng-container title>{{ copy().sections.howItWorks.title }}</ng-container>
+    <ng-container description>{{ copy().sections.howItWorks.description }}</ng-container>
+    <ul>
+      @for (item of howItems(); track $index) {
+        <li class="list-disc ml-5">{{ item }}</li>
+      }
+    </ul>
+  </app-section-content>
+
+  <app-section-content>
+    <ng-container title>{{ copy().sections.whenItRuns.title }}</ng-container>
+    <ng-container description>{{ copy().sections.whenItRuns.description }}</ng-container>
+    <ul>
+      @for (item of whenItems(); track $index) {
+        <li class="list-disc ml-5">{{ item }}</li>
+      }
+    </ul>
+  </app-section-content>
+
+  <app-section-content>
+    <ng-container title>{{ copy().sections.usage.title }}</ng-container>
+    <ng-container description>{{ copy().sections.usage.description }}</ng-container>
+    <app-code-viewer
+      language="html"
+      name="icon-usage.html"
+      src="markdown/usage/generate-icons/usage.html.md"
+    />
+  </app-section-content>
+
+  <app-section-content>
+    <ng-container title>{{ copy().sections.custom.title }}</ng-container>
+    <ng-container description>{{ copy().sections.custom.description }}</ng-container>
+  </app-section-content>
+</app-section-container>

--- a/libs/ui/src/app/features/resources/generate-icons/generate-icons.page.ts
+++ b/libs/ui/src/app/features/resources/generate-icons/generate-icons.page.ts
@@ -1,0 +1,20 @@
+import { Component, computed } from '@angular/core';
+import { Section } from '@/core/components/section';
+import { useDocsCopy, type GenerateIconsPageCopy } from '@/core/i18n/docs';
+
+@Component({
+  selector: 'app-generate-icons-page',
+  templateUrl: './generate-icons.page.html',
+  imports: [Section],
+})
+export class GenerateIconsPage {
+  private readonly docs = useDocsCopy('generate-icons');
+  readonly copy = this.docs.copy;
+  readonly common = this.docs.common;
+  readonly howItems = computed(
+    () => (this.copy() as GenerateIconsPageCopy).sections.howItWorks.items,
+  );
+  readonly whenItems = computed(
+    () => (this.copy() as GenerateIconsPageCopy).sections.whenItRuns.items,
+  );
+}

--- a/libs/ui/src/app/features/resources/routes.ts
+++ b/libs/ui/src/app/features/resources/routes.ts
@@ -29,6 +29,12 @@ export const ROUTES: Routes = [
     title: generateTitle('Rules'),
   },
   {
+    path: 'generate-icons',
+    loadComponent: () =>
+      import('./generate-icons/generate-icons.page').then((m) => m.GenerateIconsPage),
+    title: generateTitle('Generate Icons'),
+  },
+  {
     path: 'auth',
     loadComponent: () => import('./auth/auth.page').then((m) => m.AuthPage),
     title: generateTitle('Auth'),

--- a/libs/ui/src/app/shared/components/alert/alert.ts
+++ b/libs/ui/src/app/shared/components/alert/alert.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Service } from '@angular/core';
 import { AlertModal } from '.';
 import { Modal } from '../modal';
 
@@ -9,7 +9,7 @@ export interface AlertData {
   type: AlertType;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class Alert {
   private readonly modal = inject(Modal);
 

--- a/libs/ui/src/app/shared/components/bottom-sheet/bottom-sheet.ts
+++ b/libs/ui/src/app/shared/components/bottom-sheet/bottom-sheet.ts
@@ -3,7 +3,7 @@ import {
   createComponent,
   EnvironmentInjector,
   inject,
-  Injectable,
+  Service,
   InjectionToken,
   Injector,
   Type,
@@ -30,7 +30,7 @@ export interface BottomSheetConfig {
   afterClosed?: (trigger: any) => void;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class BottomSheet {
   private readonly appRef = inject(ApplicationRef);
   private readonly injector = inject(EnvironmentInjector);

--- a/libs/ui/src/app/shared/components/confirm/confirm.ts
+++ b/libs/ui/src/app/shared/components/confirm/confirm.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Service } from '@angular/core';
 import { Modal } from '../modal';
 import { ConfirmModal } from './confirm.modal';
 
@@ -15,7 +15,7 @@ export interface ConfirmResult {
   answer: boolean;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class Confirm {
   private readonly modal = inject(Modal);
 

--- a/libs/ui/src/app/shared/components/inline-filter/parts/fields/calendar/inline-filter-calendar.html
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/fields/calendar/inline-filter-calendar.html
@@ -4,7 +4,7 @@
       <app-input-calendar
         #calendarField
         format="dd/MM/yyyy"
-        [formControl]="valueControl"
+        [formField]="valueForm.value"
         [placeholder]="config.placeholder ?? 'Pick a date'"
         [inline]="!isMobile"
       />

--- a/libs/ui/src/app/shared/components/inline-filter/parts/fields/calendar/inline-filter-calendar.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/fields/calendar/inline-filter-calendar.ts
@@ -1,13 +1,13 @@
 import { InputCalendar } from '@/shared/components/calendar';
 import { Component, effect, OnInit, viewChild } from '@angular/core';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormField } from '@angular/forms/signals';
 import { KlDate } from '@koalarx/utils/KlDate';
 import { FieldBase } from '../field.base';
 
 @Component({
   selector: 'app-inline-filter-calendar',
   templateUrl: './inline-filter-calendar.html',
-  imports: [ReactiveFormsModule, InputCalendar],
+  imports: [FormField, InputCalendar],
 })
 export class InlineFilterCalendar extends FieldBase implements OnInit {
   private readonly calendarComponentRef = viewChild<InputCalendar>('calendarField');
@@ -17,9 +17,9 @@ export class InlineFilterCalendar extends FieldBase implements OnInit {
 
     effect(() => {
       const config = this.config();
-      const value = this.valueChanges();
+      const value = this.valueForm.value().value();
 
-      if (this.valueControl.invalid) {
+      if (!this.valueForm.value().valid()) {
         return;
       }
 

--- a/libs/ui/src/app/shared/components/inline-filter/parts/fields/combobox/inline-filter-combobox.html
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/fields/combobox/inline-filter-combobox.html
@@ -7,7 +7,7 @@
         [options]="options()"
         [placeholder]="config.placeholder || 'Select an option'"
         [multiple]="config.multiple"
-        [formControl]="valueControl"
+        [formField]="valueForm.value"
         [inline]="!isMobile"
       />
     }

--- a/libs/ui/src/app/shared/components/inline-filter/parts/fields/combobox/inline-filter-combobox.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/fields/combobox/inline-filter-combobox.ts
@@ -1,12 +1,12 @@
 import { Combobox, ComboboxField, ComboboxOptions } from '@/shared/components/combobox';
 import { Component, computed, effect, OnInit, viewChild } from '@angular/core';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormField } from '@angular/forms/signals';
 import { FieldBase } from '../field.base';
 
 @Component({
   selector: 'app-inline-filter-combobox',
   templateUrl: './inline-filter-combobox.html',
-  imports: [ReactiveFormsModule, Combobox],
+  imports: [FormField, Combobox],
 })
 export class InlineFilterCombobox extends FieldBase implements OnInit {
   private readonly comboboxComponentRef = viewChild<ComboboxField>('comboboxField');
@@ -20,7 +20,7 @@ export class InlineFilterCombobox extends FieldBase implements OnInit {
       const config = this.config();
       const selectedOptions = this.comboboxComponentRef()?.selectedOptions();
 
-      if (this.valueControl.invalid) {
+      if (!this.valueForm.value().valid()) {
         return;
       }
 

--- a/libs/ui/src/app/shared/components/inline-filter/parts/fields/field.base.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/fields/field.base.ts
@@ -1,6 +1,6 @@
 import { isMobile } from '@/shared/utils/is-mobile';
 import { Directive, effect, input, output, signal } from '@angular/core';
-import { ValidatorFn, Validators } from '@angular/forms';
+import { AbstractControl, ValidatorFn } from '@angular/forms';
 import { form, validate } from '@angular/forms/signals';
 import { validateCnpj, validateCpf } from '@koalarx/utils/KlString';
 import { InlineFilterField } from '../../config';
@@ -16,12 +16,6 @@ export abstract class FieldBase {
     validate(schema.value, ({ value }) => {
       const config = this.config();
       const current = value();
-
-      if (this.hasRequiredValidator(config.validators)) {
-        if (current == null || current === '' || (Array.isArray(current) && current.length === 0)) {
-          return { kind: 'required', message: `${config.label} is required` };
-        }
-      }
 
       if (config.inputType === 'email' && current) {
         const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -42,6 +36,11 @@ export abstract class FieldBase {
           : { kind: 'cnpjInvalid', message: 'CNPJ inválido' };
       }
 
+      const validatorError = this.runConfigValidators(config.validators, current, config.label);
+      if (validatorError) {
+        return validatorError;
+      }
+
       return undefined;
     });
   });
@@ -49,12 +48,28 @@ export abstract class FieldBase {
   readonly isInvalid = output<boolean>();
   readonly data = output<any>();
 
-  protected hasRequiredValidator(validators?: ValidatorFn | ValidatorFn[]): boolean {
+  /** Bridge Reactive Forms `ValidatorFn` into Signal Forms `validate`. */
+  protected runConfigValidators(
+    validators: ValidatorFn | ValidatorFn[] | undefined,
+    current: unknown,
+    label: string,
+  ) {
     if (!validators) {
-      return false;
+      return undefined;
     }
+
     const list = Array.isArray(validators) ? validators : [validators];
-    return list.includes(Validators.required);
+    const control = { value: current } as AbstractControl;
+
+    for (const validator of list) {
+      const errors = validator(control);
+      if (errors) {
+        const kind = Object.keys(errors)[0] ?? 'invalid';
+        return { kind, message: `${label} is invalid` };
+      }
+    }
+
+    return undefined;
   }
 
   constructor() {

--- a/libs/ui/src/app/shared/components/inline-filter/parts/fields/field.base.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/fields/field.base.ts
@@ -1,8 +1,8 @@
-import { controlChanges } from '@/shared/utils/control-changes';
-import { formIsValid } from '@/shared/utils/form-is-valid';
 import { isMobile } from '@/shared/utils/is-mobile';
-import { Directive, effect, input, output } from '@angular/core';
-import { FormControl } from '@angular/forms';
+import { Directive, effect, input, output, signal } from '@angular/core';
+import { ValidatorFn, Validators } from '@angular/forms';
+import { form, validate } from '@angular/forms/signals';
+import { validateCnpj, validateCpf } from '@koalarx/utils/KlString';
 import { InlineFilterField } from '../../config';
 
 @Directive()
@@ -10,29 +10,65 @@ export abstract class FieldBase {
   readonly config = input.required<InlineFilterField>();
   readonly isMobile = isMobile();
 
-  readonly valueControl = new FormControl();
-  readonly valueChanges = controlChanges(this.valueControl);
-  readonly valid = formIsValid(this.valueControl);
+  protected readonly model = signal<{ value: any }>({ value: null });
+
+  readonly valueForm = form(this.model, (schema) => {
+    validate(schema.value, ({ value }) => {
+      const config = this.config();
+      const current = value();
+
+      if (this.hasRequiredValidator(config.validators)) {
+        if (current == null || current === '' || (Array.isArray(current) && current.length === 0)) {
+          return { kind: 'required', message: `${config.label} is required` };
+        }
+      }
+
+      if (config.inputType === 'email' && current) {
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailPattern.test(String(current))) {
+          return { kind: 'email', message: 'Invalid email' };
+        }
+      }
+
+      if (config.inputType === 'cpf' && current) {
+        return validateCpf(String(current))
+          ? undefined
+          : { kind: 'cpfInvalid', message: 'CPF inválido' };
+      }
+
+      if (config.inputType === 'cnpj' && current) {
+        return validateCnpj(String(current))
+          ? undefined
+          : { kind: 'cnpjInvalid', message: 'CNPJ inválido' };
+      }
+
+      return undefined;
+    });
+  });
 
   readonly isInvalid = output<boolean>();
   readonly data = output<any>();
 
+  protected hasRequiredValidator(validators?: ValidatorFn | ValidatorFn[]): boolean {
+    if (!validators) {
+      return false;
+    }
+    const list = Array.isArray(validators) ? validators : [validators];
+    return list.includes(Validators.required);
+  }
+
   constructor() {
     effect(() => {
-      this.valueControl.setValue(this.config().value());
-    });
-
-    effect(() => {
-      const config = this.config();
-
-      if (config.validators) {
-        this.valueControl.setValidators(config.validators);
+      const configValue = this.config().value();
+      if (this.model().value !== configValue) {
+        this.model.set({ value: configValue });
       }
     });
 
     effect(() => {
-      const isInvalid = !this.valid();
-      const value = this.valueChanges();
+      const field = this.valueForm.value;
+      const value = field().value();
+      const isInvalid = !field().valid();
 
       this.config().invalid.set(isInvalid);
       this.config().value.set(isInvalid ? null : value);

--- a/libs/ui/src/app/shared/components/inline-filter/parts/fields/input/inline-filter-input.html
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/fields/input/inline-filter-input.html
@@ -18,7 +18,7 @@
         [style.width]="widthField + 'ch'"
         [type]="config.inputType"
         [placeholder]="config.placeholder ?? 'Digite um valor'"
-        [formControl]="valueControl"
+        [formField]="valueForm.value"
       />
     }
     @case ('cpf')
@@ -30,7 +30,7 @@
         type="text"
         [appMask]="mask"
         [placeholder]="mask"
-        [formControl]="valueControl"
+        [formField]="valueForm.value"
       />
     }
     @case ('currency') {
@@ -41,7 +41,7 @@
         type="text"
         appCurrency
         placeholder="R$ 0,00"
-        [formControl]="valueControl"
+        [formField]="valueForm.value"
       />
     }
   }

--- a/libs/ui/src/app/shared/components/inline-filter/parts/fields/input/inline-filter-input.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/fields/input/inline-filter-input.ts
@@ -1,16 +1,14 @@
 import { CurrencyMask } from '@/shared/directives/currency.directive';
 import { Mask } from '@/shared/directives/mask.directive';
-import { CnpjValidator } from '@/shared/validators/cnpj.validator';
-import { CpfValidator } from '@/shared/validators/cpf.validator';
 import { Component, effect, ElementRef, OnInit, viewChild } from '@angular/core';
-import { ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormField } from '@angular/forms/signals';
 import { maskCoin } from '@koalarx/utils/KlNumber';
 import { FieldBase } from '../field.base';
 
 @Component({
   selector: 'app-inline-filter-input',
   templateUrl: './inline-filter-input.html',
-  imports: [ReactiveFormsModule, Mask, CurrencyMask],
+  imports: [FormField, Mask, CurrencyMask],
 })
 export class InlineFilterInput extends FieldBase implements OnInit {
   private readonly inputElement = viewChild<ElementRef<HTMLInputElement>>('inputField');
@@ -20,9 +18,10 @@ export class InlineFilterInput extends FieldBase implements OnInit {
 
     effect(() => {
       const config = this.config();
-      const value = this.valueChanges();
+      const value = this.valueForm.value().value();
+      const invalid = !this.valueForm.value().valid();
 
-      if (!this.valueControl.invalid) {
+      if (!invalid) {
         config.templateValue.set(config.inputType === 'currency' ? maskCoin(value) : value);
       } else {
         config.templateValue.set('');
@@ -31,16 +30,6 @@ export class InlineFilterInput extends FieldBase implements OnInit {
   }
 
   ngOnInit(): void {
-    const config = this.config();
-
-    if (config.inputType === 'cpf') {
-      this.valueControl.addValidators(CpfValidator);
-    } else if (config.inputType === 'cnpj') {
-      this.valueControl.addValidators(CnpjValidator);
-    } else if (config.inputType === 'email') {
-      this.valueControl.addValidators(Validators.email);
-    }
-
     setTimeout(() => {
       this.inputElement()?.nativeElement.focus();
     });

--- a/libs/ui/src/app/shared/components/inline-filter/parts/fields/select/inline-filter-select.html
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/fields/select/inline-filter-select.html
@@ -7,7 +7,7 @@
         [options]="options()"
         [placeholder]="config.placeholder || 'Select an option'"
         [multiple]="config.multiple"
-        [formControl]="valueControl"
+        [formField]="valueForm.value"
         [inline]="!isMobile"
         hideClear
       />

--- a/libs/ui/src/app/shared/components/inline-filter/parts/fields/select/inline-filter-select.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/fields/select/inline-filter-select.ts
@@ -1,12 +1,12 @@
 import { Select, SelectField, SelectOption } from '@/shared/components/select';
 import { Component, computed, effect, OnInit, ResourceRef, viewChild } from '@angular/core';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormField } from '@angular/forms/signals';
 import { FieldBase } from '../field.base';
 
 @Component({
   selector: 'app-inline-filter-select',
   templateUrl: './inline-filter-select.html',
-  imports: [ReactiveFormsModule, Select],
+  imports: [FormField, Select],
 })
 export class InlineFilterSelect extends FieldBase implements OnInit {
   private readonly selectComponentRef = viewChild<SelectField>('selectField');
@@ -24,10 +24,10 @@ export class InlineFilterSelect extends FieldBase implements OnInit {
 
     effect(() => {
       const config = this.config();
-      const value = this.valueChanges();
+      const value = this.valueForm.value().value();
       const options = this.options();
 
-      if (this.valueControl.invalid) {
+      if (!this.valueForm.value().valid()) {
         return;
       }
 

--- a/libs/ui/src/app/shared/components/inline-filter/parts/picker/mobile-picker.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/picker/mobile-picker.ts
@@ -82,10 +82,22 @@ export class MobilePicker {
     const queryParams = this.activatedRoute.snapshot.queryParams ?? {};
 
     return Object.fromEntries(
-      this.config.fields.map((field) => [
-        field.name,
-        queryParams[field.name] ?? field.defaultValue ?? null,
-      ]),
+      this.config.fields.map((field) => {
+        const fromField = field.value();
+        const fromQuery = queryParams[field.name];
+        const raw = fromField ?? fromQuery ?? field.defaultValue ?? null;
+
+        if (raw == null || raw === '') {
+          return [field.name, null];
+        }
+
+        if (typeof raw === 'string') {
+          const numeric = Number(raw);
+          return [field.name, Number.isNaN(numeric) ? raw : numeric];
+        }
+
+        return [field.name, raw];
+      }),
     );
   }
 

--- a/libs/ui/src/app/shared/components/inline-filter/parts/picker/mobile-picker.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/parts/picker/mobile-picker.ts
@@ -12,7 +12,7 @@ import { Select, SelectOption } from '@/shared/components/select';
 import { CurrencyMask } from '@/shared/directives/currency.directive';
 import { Mask } from '@/shared/directives/mask.directive';
 import { Component, inject, ResourceRef, signal } from '@angular/core';
-import { ValidatorFn, Validators } from '@angular/forms';
+import { AbstractControl, ValidatorFn, Validators } from '@angular/forms';
 import { email, form, FormField, required, validate } from '@angular/forms/signals';
 import { ActivatedRoute, Router } from '@angular/router';
 import { validateCnpj, validateCpf } from '@koalarx/utils/KlString';
@@ -61,7 +61,9 @@ export class MobilePicker {
             return undefined;
           }
 
-          return validateCpf(current) ? undefined : { kind: 'cpfInvalid', message: 'CPF inválido' };
+          return validateCpf(String(current))
+            ? undefined
+            : { kind: 'cpfInvalid', message: 'CPF inválido' };
         });
       } else if (field.inputType === 'cnpj') {
         validate(path, ({ value }) => {
@@ -70,11 +72,13 @@ export class MobilePicker {
             return undefined;
           }
 
-          return validateCnpj(current)
+          return validateCnpj(String(current))
             ? undefined
             : { kind: 'cnpjInvalid', message: 'CNPJ inválido' };
         });
       }
+
+      this.applyExtraValidators(path, field);
     }
   });
 
@@ -91,7 +95,8 @@ export class MobilePicker {
           return [field.name, null];
         }
 
-        if (typeof raw === 'string') {
+        // Only currency (and similar) should become numbers; CPF/CNPJ/select keys stay strings.
+        if (typeof raw === 'string' && field.inputType === 'currency') {
           const numeric = Number(raw);
           return [field.name, Number.isNaN(numeric) ? raw : numeric];
         }
@@ -99,6 +104,35 @@ export class MobilePicker {
         return [field.name, raw];
       }),
     );
+  }
+
+  private applyExtraValidators(path: any, field: InlineFilterField) {
+    if (!field.validators) {
+      return;
+    }
+
+    const list = (Array.isArray(field.validators) ? field.validators : [field.validators]).filter(
+      (validator) => validator !== Validators.required,
+    );
+
+    if (list.length === 0) {
+      return;
+    }
+
+    validate(path, ({ value }) => {
+      const current = value();
+      const control = { value: current } as AbstractControl;
+
+      for (const validator of list) {
+        const errors = validator(control);
+        if (errors) {
+          const kind = Object.keys(errors)[0] ?? 'invalid';
+          return { kind, message: `${field.label} is invalid` };
+        }
+      }
+
+      return undefined;
+    });
   }
 
   private hasRequiredValidator(validators?: ValidatorFn | ValidatorFn[]): boolean {

--- a/libs/ui/src/app/shared/components/inline-filter/utils/query-params-to-options/validate-options.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/utils/query-params-to-options/validate-options.ts
@@ -1,5 +1,5 @@
 import { validateCnpj, validateCpf } from '@koalarx/utils/KlString';
-import { ValidatorFn, Validators } from '@angular/forms';
+import { AbstractControl, ValidatorFn, Validators } from '@angular/forms';
 import { InlineFilterField } from '../../config';
 import { coerceValue } from './coerce-value';
 
@@ -9,6 +9,29 @@ function hasRequiredValidator(validators?: ValidatorFn | ValidatorFn[]): boolean
   }
   const list = Array.isArray(validators) ? validators : [validators];
   return list.includes(Validators.required);
+}
+
+function runConfigValidators(
+  validators: ValidatorFn | ValidatorFn[] | undefined,
+  value: unknown,
+): boolean {
+  if (!validators) {
+    return true;
+  }
+
+  const list = Array.isArray(validators) ? validators : [validators];
+  const control = { value } as AbstractControl;
+
+  for (const validator of list) {
+    if (validator === Validators.required) {
+      continue;
+    }
+    if (validator(control)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 export function validateOption(option: InlineFilterField, queryParam: string | string[]): boolean {
@@ -32,5 +55,5 @@ export function validateOption(option: InlineFilterField, queryParam: string | s
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(value));
   }
 
-  return true;
+  return runConfigValidators(option.validators, value);
 }

--- a/libs/ui/src/app/shared/components/inline-filter/utils/query-params-to-options/validate-options.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/utils/query-params-to-options/validate-options.ts
@@ -1,22 +1,36 @@
-import { CnpjValidator } from '@/shared/validators/cnpj.validator';
-import { CpfValidator } from '@/shared/validators/cpf.validator';
-import { FormControl } from '@angular/forms';
+import { validateCnpj, validateCpf } from '@koalarx/utils/KlString';
+import { ValidatorFn, Validators } from '@angular/forms';
 import { InlineFilterField } from '../../config';
 import { coerceValue } from './coerce-value';
 
+function hasRequiredValidator(validators?: ValidatorFn | ValidatorFn[]): boolean {
+  if (!validators) {
+    return false;
+  }
+  const list = Array.isArray(validators) ? validators : [validators];
+  return list.includes(Validators.required);
+}
+
 export function validateOption(option: InlineFilterField, queryParam: string | string[]): boolean {
   const value = Array.isArray(queryParam) ? queryParam.map(coerceValue) : coerceValue(queryParam);
-  const validators = option.validators;
 
-  const formControl = new FormControl(value, validators);
-
-  if (option.inputType === 'cpf') {
-    formControl.addValidators(CpfValidator);
-  } else if (option.inputType === 'cnpj') {
-    formControl.addValidators(CnpjValidator);
+  if (hasRequiredValidator(option.validators)) {
+    if (value == null || value === '' || (Array.isArray(value) && value.length === 0)) {
+      return false;
+    }
   }
 
-  formControl.updateValueAndValidity();
+  if (option.inputType === 'cpf') {
+    return typeof value === 'string' ? validateCpf(value) : false;
+  }
 
-  return formControl.valid;
+  if (option.inputType === 'cnpj') {
+    return typeof value === 'string' ? validateCnpj(value) : false;
+  }
+
+  if (option.inputType === 'email' && value) {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(value));
+  }
+
+  return true;
 }

--- a/libs/ui/src/app/shared/components/inline-filter/wrapper.ts
+++ b/libs/ui/src/app/shared/components/inline-filter/wrapper.ts
@@ -14,6 +14,7 @@ interface QueryParams {
   [key: string]: any;
   page?: string;
   pageSize?: string;
+  limit?: string;
 }
 
 @Component({
@@ -45,6 +46,7 @@ export class Wrapper implements OnInit {
 
       delete queryParams.page;
       delete queryParams.pageSize;
+      delete queryParams.limit;
 
       const selectedOptions = signal<InlineFilterField[]>([]);
 

--- a/libs/ui/src/app/shared/components/modal/modal.ts
+++ b/libs/ui/src/app/shared/components/modal/modal.ts
@@ -3,7 +3,7 @@ import {
   createComponent,
   EnvironmentInjector,
   inject,
-  Injectable,
+  Service,
   InjectionToken,
   Injector,
   Type,
@@ -30,7 +30,7 @@ export interface ModalConfig {
   afterClosed?: (trigger: any) => void;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class Modal {
   private readonly appRef = inject(ApplicationRef);
   private readonly injector = inject(EnvironmentInjector);

--- a/libs/ui/src/app/shared/components/pagination/pagination.html
+++ b/libs/ui/src/app/shared/components/pagination/pagination.html
@@ -47,7 +47,7 @@
         type="button"
         class="join-item btn"
         [class]="sizeClass()"
-        [class.btn-active]="page === currentPage()"
+        [class.btn-primary]="page === currentPage()"
         [disabled]="page < 0"
         (click)="setPage(page)"
       >

--- a/libs/ui/src/app/shared/components/pagination/pagination.ts
+++ b/libs/ui/src/app/shared/components/pagination/pagination.ts
@@ -20,15 +20,15 @@ export class Pagination {
     this.activatedRoute.queryParamMap.pipe(
       map((params) => {
         const page = params.get('page');
-        const pageSize = params.get('pageSize');
+        const limit = params.get('limit') ?? params.get('pageSize');
 
         return {
-          page: page ? Number(page) : 1,
-          pageSize: pageSize ? Number(pageSize) : 10,
+          page: page != null ? Number(page) : null,
+          pageSize: limit != null ? Number(limit) : null,
         };
       }),
     ),
-    { initialValue: { page: 1, pageSize: 10 } },
+    { initialValue: { page: null as number | null, pageSize: null as number | null } },
   );
 
   readonly isMobile = isMobile();
@@ -45,7 +45,7 @@ export class Pagination {
 
   readonly size = input<PaginationSize>('md');
   readonly page = input<number>(1);
-  readonly pageSize = input<number>(10);
+  readonly pageSize = input<number>(30);
   readonly total = input<number>(0);
 
   readonly currentPage = linkedSignal<number>(this.page);
@@ -134,7 +134,7 @@ export class Pagination {
 
       this.pageSizeChange.emit(pageSize);
       this.router.navigate([], {
-        queryParams: { pageSize },
+        queryParams: { limit: pageSize, pageSize: null },
         queryParamsHandling: 'merge',
       });
     });
@@ -142,8 +142,8 @@ export class Pagination {
     effect(() => {
       const { page, pageSize } = this.paginationParams();
 
-      this.currentPage.set(page);
-      this.currentPageSize.set(pageSize);
+      this.currentPage.set(page ?? this.page());
+      this.currentPageSize.set(pageSize ?? this.pageSize());
     });
   }
 

--- a/libs/ui/src/app/shared/components/side-window/side-window.ts
+++ b/libs/ui/src/app/shared/components/side-window/side-window.ts
@@ -3,7 +3,7 @@ import {
   createComponent,
   EnvironmentInjector,
   inject,
-  Injectable,
+  Service,
   InjectionToken,
   Injector,
   Type,
@@ -30,7 +30,7 @@ export interface SideWindowConfig {
   afterClosed?: (trigger: any) => void;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class SideWindow {
   private readonly appRef = inject(ApplicationRef);
   private readonly injector = inject(EnvironmentInjector);

--- a/libs/ui/src/app/shared/components/toast/toast.ts
+++ b/libs/ui/src/app/shared/components/toast/toast.ts
@@ -3,7 +3,7 @@ import {
   createComponent,
   EnvironmentInjector,
   inject,
-  Injectable,
+  Service,
   InjectionToken,
   Injector,
 } from '@angular/core';
@@ -26,7 +26,7 @@ export interface ToastOptions {
   timeout?: number;
 }
 
-@Injectable({ providedIn: 'root' })
+@Service()
 export class Toast {
   private readonly appRef = inject(ApplicationRef);
   private readonly injector = inject(EnvironmentInjector);

--- a/libs/ui/src/app/shared/directives/currency.directive.ts
+++ b/libs/ui/src/app/shared/directives/currency.directive.ts
@@ -35,7 +35,8 @@ export class CurrencyMask implements FormValueControl<number | null>, OnDestroy 
     const el = this.elementRef.nativeElement;
     const sep = this.getSep();
     const thousandSep = this.thousandSeparator() || '.';
-    const prefix = this.prefix();
+    // Match currencyMask default alias when prefix input is unset.
+    const prefix = this.prefix() ?? 'R$';
 
     let rawValue = el.value;
     if (prefix) {

--- a/libs/ui/src/app/shared/directives/currency.directive.ts
+++ b/libs/ui/src/app/shared/directives/currency.directive.ts
@@ -31,6 +31,33 @@ export class CurrencyMask implements FormValueControl<number | null>, OnDestroy 
   readonly disabled = input(false);
   readonly touch = output<void>();
 
+  private readonly onInput = () => {
+    const el = this.elementRef.nativeElement;
+    const sep = this.getSep();
+    const thousandSep = this.thousandSeparator() || '.';
+    const prefix = this.prefix();
+
+    let rawValue = el.value;
+    if (prefix) {
+      rawValue = rawValue.replace(prefix, '').trimStart();
+    }
+    rawValue = rawValue.split(thousandSep).join('');
+
+    const maskedValue = currencyMask(rawValue || '0', {
+      currencyAlias: prefix,
+      decimalDigits: this.getSafeDecimalDigits(),
+      thousandSeparator: thousandSep,
+      decimalSeparator: sep,
+      fixedDecimalScale: true,
+    });
+
+    el.value = maskedValue;
+
+    if (!this.suppressEmit) {
+      this.emitNumericValue(rawValue || '0');
+    }
+  };
+
   private readonly onKeyDown = (event: KeyboardEvent) => this.handleKeyDown(event);
   private readonly onClick = () => this.syncEditingModeFromCaret();
   private readonly onPaste = (event: ClipboardEvent) => {
@@ -47,16 +74,32 @@ export class CurrencyMask implements FormValueControl<number | null>, OnDestroy 
 
   constructor() {
     const el = this.elementRef.nativeElement;
+    el.addEventListener('input', this.onInput);
     el.addEventListener('keydown', this.onKeyDown);
     el.addEventListener('click', this.onClick);
     el.addEventListener('paste', this.onPaste);
 
     effect(() => {
-      this.render(this.elementRef.nativeElement.value);
-    });
+      const value = this.value();
+      const sep = this.getSep();
+      const safeDecimalDigits = this.getSafeDecimalDigits();
+      const raw =
+        value == null || isNaN(value) ? '0' : value.toFixed(safeDecimalDigits).replace('.', sep);
+      const masked = currencyMask(raw, {
+        currencyAlias: this.prefix(),
+        decimalDigits: safeDecimalDigits,
+        thousandSeparator: this.thousandSeparator(),
+        decimalSeparator: sep,
+        fixedDecimalScale: true,
+      });
 
-    effect(() => {
-      this.applyExternalValue(this.value());
+      if (el.value === masked) {
+        return;
+      }
+
+      this.suppressEmit = true;
+      el.value = masked;
+      this.suppressEmit = false;
     });
 
     effect(() => {
@@ -218,6 +261,7 @@ export class CurrencyMask implements FormValueControl<number | null>, OnDestroy 
 
   ngOnDestroy(): void {
     const el = this.elementRef.nativeElement;
+    el.removeEventListener('input', this.onInput);
     el.removeEventListener('keydown', this.onKeyDown);
     el.removeEventListener('click', this.onClick);
     el.removeEventListener('paste', this.onPaste);

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "@koalarx/ui",
-  "version": "23.0.3",
+  "version": "23.1.0",
+  "type": "module",
   "scripts": {
-    "build": "bun scripts/build",
+    "build": "bun scripts/build.mjs",
+    "build:cli": "bun scripts/build-cli.mjs",
+    "build:ui": "bun scripts/build-ui.mjs",
     "build:doc": "bun run build:docs",
     "build:docs": "bun run generate:llms && cd libs/ui && bun run build:prod",
     "dev:docs": "bun run generate:llms && cd libs/ui && bun start",
     "preview:docs": "bunx serve dist/browser -p 4321",
-    "start": "bun run build && bun ./bin/run",
+    "start": "bun run build && bun dist/cli/index.js",
     "ui:start": "cd libs/ui && bun start",
     "generate:command": "bun scripts/generate-command",
     "generate:llms": "node scripts/generate-llms.js",
@@ -64,7 +67,7 @@
     "typescript": "^6"
   },
   "bin": {
-    "kl": "./bin/run.js"
+    "kl": "./dist/cli/index.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env bun
+
+import { Glob } from "bun";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourceDir = path.join(rootDir, "libs/cli");
+const outputDir = path.join(rootDir, "dist/cli");
+
+const transpiler = new Bun.Transpiler({
+  loader: "ts",
+  target: "node",
+});
+
+function shouldSkipFile(file) {
+  if (file.startsWith("test/")) {
+    return true;
+  }
+
+  if (file.endsWith(".unit.spec.ts") || file.endsWith(".spec.ts")) {
+    return true;
+  }
+
+  if (file.startsWith("vitest.config")) {
+    return true;
+  }
+
+  return false;
+}
+
+function rewriteRelativeImports(code, sourceFile) {
+  function normalizeImportPath(importPath) {
+    if (importPath.endsWith(".json")) {
+      return importPath;
+    }
+
+    if (importPath.endsWith(".ts")) {
+      return `${importPath.slice(0, -3)}.js`;
+    }
+
+    if (importPath.endsWith(".js")) {
+      return importPath;
+    }
+
+    return `${importPath}.js`;
+  }
+
+  function resolveImportPath(importPath) {
+    if (!importPath.startsWith("@cli/")) {
+      return importPath;
+    }
+
+    const targetPath = path.join(sourceDir, importPath.slice("@cli/".length));
+    const fromDir = path.dirname(path.join(sourceDir, sourceFile));
+    let relative = path.relative(fromDir, targetPath).replace(/\\/g, "/");
+
+    if (!relative.startsWith(".")) {
+      relative = `./${relative}`;
+    }
+
+    return relative;
+  }
+
+  function rewriteStatement(match, quote, importPath) {
+    const resolved = resolveImportPath(importPath);
+    const normalized = normalizeImportPath(resolved);
+
+    return match.replace(
+      `${quote}${importPath}${quote}`,
+      `${quote}${normalized}${quote}`,
+    );
+  }
+
+  let output = code.replace(
+    /^import\s+(?:type\s+)?(?:[\s\S]*?\s+)from\s+(['"])((?:@cli\/|\.\.?\/)[^'"]+)\1;?\s*$/gm,
+    rewriteStatement,
+  );
+
+  output = output.replace(
+    /^export\s+(?:type\s+)?(?:[\s\S]*?\s+)from\s+(['"])((?:@cli\/|\.\.?\/)[^'"]+)\1;?\s*$/gm,
+    rewriteStatement,
+  );
+
+  if (/with\s+\{\s*type:\s*["']json["']\s*\}/.test(sourceFile)) {
+    output = output.replace(
+      /import\s+(\w+)\s+from\s+["']([^"']+\.json)["']/g,
+      'import $1 from "$2" with { type: "json" }',
+    );
+  }
+
+  return output;
+}
+
+function buildCli() {
+  rmSync(outputDir, { recursive: true, force: true });
+
+  for (const file of new Glob("**/*.ts").scanSync(sourceDir)) {
+    if (shouldSkipFile(file)) {
+      continue;
+    }
+
+    const sourcePath = path.join(sourceDir, file);
+    const outputPath = path.join(outputDir, file.replace(/\.ts$/, ".js"));
+
+    mkdirSync(path.dirname(outputPath), { recursive: true });
+
+    const source = readFileSync(sourcePath, "utf8");
+    let output = transpiler.transformSync(source);
+    output = rewriteRelativeImports(output, file);
+
+    if (file === "index.ts") {
+      output = `#!/usr/bin/env bun\n\n${output}`;
+    }
+
+    writeFileSync(outputPath, output, "utf8");
+  }
+
+  const assetsSource = path.join(sourceDir, "assets");
+  const assetsOutput = path.join(outputDir, "assets");
+
+  if (existsSync(assetsSource)) {
+    cpSync(assetsSource, assetsOutput, { recursive: true });
+  }
+
+  console.log(`Build concluído: ${path.relative(rootDir, outputDir)}/`);
+}
+
+buildCli();

--- a/scripts/build-ui.mjs
+++ b/scripts/build-ui.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+
+import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const distUiDir = path.join(rootDir, "dist/ui");
+
+mkdirSync(distUiDir, { recursive: true });
+
+cpSync(
+  path.join(rootDir, "libs/ui/.vscode/settings.json"),
+  path.join(distUiDir, ".vscode/settings.json"),
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/core/constants/security-storage-keys.ts"),
+  path.join(distUiDir, "core/constants/security-storage-keys.ts"),
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/core/guards"),
+  path.join(distUiDir, "core/guards"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/core/interceptors"),
+  path.join(distUiDir, "core/interceptors"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/core/middlewares"),
+  path.join(distUiDir, "core/middlewares"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/core/models"),
+  path.join(distUiDir, "core/models"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/core/security"),
+  path.join(distUiDir, "core/security"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/core/utils"),
+  path.join(distUiDir, "core/utils"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/shared/components"),
+  path.join(distUiDir, "components"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/shared/validators"),
+  path.join(distUiDir, "validators"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/shared/directives"),
+  path.join(distUiDir, "directives"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/shared/utils"),
+  path.join(distUiDir, "utils"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/shared/base"),
+  path.join(distUiDir, "base"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/theme"),
+  path.join(distUiDir, "theme"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/public/assets/icons"),
+  path.join(distUiDir, "assets/icons"),
+  { recursive: true },
+);
+cpSync(
+  path.join(rootDir, "libs/ui/src/app/app.ts"),
+  path.join(distUiDir, "app.ts"),
+);
+
+cpSync(
+  path.join(rootDir, "libs/ui/src/styles.css"),
+  path.join(distUiDir, "styles.css"),
+);
+const styles = readFileSync(path.join(distUiDir, "styles.css"), "utf-8");
+writeFileSync(
+  path.join(distUiDir, "styles.css"),
+  styles.replace(/\/\* --start-internal-- \*\/[\s\S]*?\/\* --end-internal-- \*\//g, ""),
+);
+
+cpSync(
+  path.join(rootDir, "libs/ui/eslint.config.mts"),
+  path.join(distUiDir, "eslint.config.mts"),
+);
+cpSync(
+  path.join(rootDir, "libs/ui/generate-icons.js"),
+  path.join(distUiDir, "generate-icons.js"),
+);
+
+console.log(`Build concluído: ${path.relative(rootDir, distUiDir)}/`);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+
+import { cpSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const distDir = path.join(rootDir, "dist");
+
+function runBuildScript(scriptName) {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(rootDir, "scripts", scriptName)],
+    {
+      cwd: rootDir,
+      stdio: "inherit",
+    },
+  );
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function copyPackageMetadata() {
+  cpSync(path.join(rootDir, "README.md"), path.join(distDir, "README.md"));
+  cpSync(path.join(rootDir, "LICENSE"), path.join(distDir, "LICENSE"));
+
+  const rootPackage = JSON.parse(
+    readFileSync(path.join(rootDir, "package.json"), "utf8"),
+  );
+
+  const publishPackage = {
+    name: rootPackage.name,
+    version: rootPackage.version,
+    description: rootPackage.description,
+    license: rootPackage.license,
+    type: rootPackage.type,
+    bin: {
+      kl: "./cli/index.js",
+    },
+    repository: rootPackage.repository,
+    author: rootPackage.author,
+    bugs: rootPackage.bugs,
+    homepage: rootPackage.homepage,
+    keywords: rootPackage.keywords,
+    publishConfig: rootPackage.publishConfig,
+    peerDependencies: rootPackage.peerDependencies,
+    files: ["cli", "ui", "README.md", "LICENSE"],
+    dependencies: rootPackage.dependencies,
+  };
+
+  writeFileSync(
+    path.join(distDir, "package.json"),
+    `${JSON.stringify(publishPackage, null, 2)}\n`,
+  );
+}
+
+runBuildScript("build-cli.mjs");
+runBuildScript("build-ui.mjs");
+copyPackageMetadata();
+
+console.log(`Build concluído: ${path.relative(rootDir, distDir)}/`);

--- a/scripts/generate-llms.js
+++ b/scripts/generate-llms.js
@@ -115,6 +115,8 @@ const COMPONENTS = [
   { name: 'global-errors', label: 'Global Errors' },
   { name: 'rules', label: 'Rules' },
   { name: 'auth', label: 'Auth' },
+  // Native scaffold script (not `kl install`) — still generates docs/llms entry
+  { name: 'generate-icons', label: 'Generate Icons', noKlInstall: true },
 ];
 
 // ---------------------------------------------------------------------------
@@ -188,9 +190,13 @@ ${addResources}
 
 ## Available components
 
-${COMPONENTS.filter((c) => !c.isPage)
+${COMPONENTS.filter((c) => !c.isPage && !c.noKlInstall)
   .map((c) => `- **${c.label}** – \`kl install -n ${c.name}\``)
   .join('\n')}
+
+## Native tooling
+
+- **Generate Icons** – ships with \`kl new\` / \`kl init\` (\`generate-icons.js\`). Docs: [Generate Icons](https://ui.koalarx.com/#/resources/generate-icons).
 `;
 
   return doc.trim();
@@ -447,7 +453,7 @@ function stripMarkdown(text) {
 }
 
 function getCategoryForDoc(name) {
-  const resources = ['list-base', 'http-base', 'page-base', 'global-errors', 'rules', 'auth'];
+  const resources = ['list-base', 'http-base', 'page-base', 'global-errors', 'rules', 'auth', 'generate-icons'];
   const blocks = ['datatable', 'login'];
   if (resources.includes(name)) return 'Resources';
   if (blocks.includes(name)) return 'Blocks';
@@ -455,7 +461,7 @@ function getCategoryForDoc(name) {
 }
 
 function getRouteForDoc(name) {
-  const resources = ['list-base', 'http-base', 'page-base', 'global-errors', 'rules', 'auth'];
+  const resources = ['list-base', 'http-base', 'page-base', 'global-errors', 'rules', 'auth', 'generate-icons'];
   const blocks = ['datatable', 'login'];
   if (resources.includes(name)) return `resources/${name}`;
   if (blocks.includes(name)) return `blocks/${name}`;


### PR DESCRIPTION
## Summary
- `kl new` com app/library + SSR, AI context antes do scaffold, e build da CLI no formato koala-nest (`dist/cli/index.js`)
- Inline-filter em Signal Forms; currency mask; pagination com `page`/`limit` e default 30; root services com `@Service()`
- Docs do `generate-icons`, patch notes/CHANGELOG 23.1.0, e label seguro no seletor de versão

## Test plan
- [ ] `bun run test:cli` passa
- [ ] `bun run build` e `bun dist/cli/index.js version` → `23.1.0`
- [ ] Smoke `kl new` com `--type library`, `--ssr`, `--ai-context`
- [ ] Pagination/inline-filter currency no sample docs
- [ ] Página Resources → Generate Icons


Made with [Cursor](https://cursor.com)