### PR TITLE
fix: seletor de versão das docs (22.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ O conteúdo principal da página web vive em `libs/ui/src/app/core/i18n/docs/pag
 
 Formato inspirado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/).
 
+## [22.3.5] — Seletor de versão das docs
+
+### Fixed
+
+- `DOCS_VERSIONS` sincronizado com `main` (`v23` + `v22`).
+- Label ativo do seletor só mostra o semver quando o major da build coincide com a entrada.
+
+### Upgrade
+
+Redeploy das docs da linha 22; sem mudanças nos projetos consumidores.
+
 ## [22.3.3] — Sem vazamento de docs na CLI
 
 ### Fixed

--- a/libs/ui/src/app/core/components/header/header.html
+++ b/libs/ui/src/app/core/components/header/header.html
@@ -17,7 +17,7 @@
         [class.opacity-50]="!isDocsVersionCurrent(entry)"
         (click)="switchDocsVersion(entry)"
       >
-        {{ entry.label }}
+        {{ docsVersionLabel(entry) }}
       </button>
     }
   </div>

--- a/libs/ui/src/app/core/components/header/header.ts
+++ b/libs/ui/src/app/core/components/header/header.ts
@@ -5,6 +5,7 @@ import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { filter } from 'rxjs';
+import { APP_VERSION } from '../../constants/app-version';
 import type { DocsVersionEntry } from '../../constants/docs-versions';
 import { DocsVersionService } from '../../docs-version/docs-version.service';
 import { LocalePathPipe } from '../../i18n/locale-path.pipe';
@@ -42,6 +43,7 @@ export class Header {
 
   readonly copied = signal(false);
   readonly docsVersions = this.docsVersion.versions;
+  readonly appVersion = APP_VERSION;
   readonly mobileMenuVisible = signal(false);
   readonly mobileMenuOpen = signal(false);
 
@@ -60,6 +62,14 @@ export class Header {
 
   isDocsVersionCurrent(entry: DocsVersionEntry) {
     return this.docsVersion.isCurrent(entry);
+  }
+
+  /** Active line shows full semver when it matches entry major; others keep short label. */
+  docsVersionLabel(entry: DocsVersionEntry) {
+    if (!this.isDocsVersionCurrent(entry)) {
+      return entry.label;
+    }
+    return this.appVersion.startsWith(`${entry.major}.`) ? this.appVersion : entry.label;
   }
 
   copyLlmsUrl() {

--- a/libs/ui/src/app/core/constants/app-version.ts
+++ b/libs/ui/src/app/core/constants/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '22.3.4';
+export const APP_VERSION = '22.3.5';

--- a/libs/ui/src/app/core/constants/docs-versions.ts
+++ b/libs/ui/src/app/core/constants/docs-versions.ts
@@ -15,11 +15,8 @@ export interface DocsVersionEntry {
   label: string;
 }
 
-/**
- * Bootstrap (both lines still 22.x): latest at `/`, previous-release compose at `/v22/`.
- * When 23 ships on `main`, change the first entry to major/label `23` / `v23`.
- */
+/** Latest (`main` 23.x) at `/`; previous-release (22.x) compose at `/v22/`. */
 export const DOCS_VERSIONS: readonly DocsVersionEntry[] = [
-  { major: '22', basePath: '/', label: 'v22' },
+  { major: '23', basePath: '/', label: 'v23' },
   { major: '22', basePath: '/v22/', label: 'v22' },
 ] as const;

--- a/libs/ui/src/app/core/i18n/docs/pages/patch-notes.ts
+++ b/libs/ui/src/app/core/i18n/docs/pages/patch-notes.ts
@@ -12,6 +12,15 @@ export const PATCH_NOTES_PAGE = {
         description:
           'A versão publicada do pacote @koalarx/ui aparece no package.json do repositório. O arquivo CHANGELOG.md na raiz espelha estas notas.',
       },
+      v2235: {
+        title: '22.3.5 — Seletor de versão das docs',
+        description: 'Corrige o seletor de major nas docs hospedadas em /v22/.',
+        items: [
+          'DOCS_VERSIONS sincronizado com main (v23 + v22).',
+          'Label ativo só mostra o semver quando o major da build coincide com a entrada.',
+        ],
+        upgrade: 'Redeploy das docs da linha 22; sem mudanças nos projetos consumidores.',
+      },
       v2233: {
         title: '22.3.3 — Sem vazamento de docs na CLI',
         description:
@@ -56,6 +65,15 @@ export const PATCH_NOTES_PAGE = {
         title: 'How to use these notes',
         description:
           'The published @koalarx/ui package version is in the repository package.json. The root CHANGELOG.md mirrors these notes.',
+      },
+      v2235: {
+        title: '22.3.5 — Docs version switcher',
+        description: 'Fixes the major selector on docs hosted at /v22/.',
+        items: [
+          'DOCS_VERSIONS synced with main (v23 + v22).',
+          'Active label shows semver only when the build major matches the entry.',
+        ],
+        upgrade: 'Redeploy the 22.x docs line; no consumer project changes.',
       },
       v2233: {
         title: '22.3.3 — No docs leakage in the CLI',

--- a/libs/ui/src/app/features/getting-started/patch-notes/patch-notes.page.html
+++ b/libs/ui/src/app/features/getting-started/patch-notes/patch-notes.page.html
@@ -8,6 +8,22 @@
   </app-section-content>
 
   <app-section-content class="block mt-10">
+    <ng-container title>{{ copy().sections.v2235.title }}</ng-container>
+    <ng-container description>{{ copy().sections.v2235.description }}</ng-container>
+
+    <ul class="list-disc pl-5 mt-4 space-y-2 text-sm font-light">
+      @for (item of copy().sections.v2235.items; track item) {
+        <li>{{ item }}</li>
+      }
+    </ul>
+
+    <div role="alert" class="alert alert-info alert-dash mt-4">
+      <i class="fa-solid fa-circle-info"></i>
+      <span>{{ copy().sections.v2235.upgrade }}</span>
+    </div>
+  </app-section-content>
+
+  <app-section-content class="block mt-10">
     <ng-container title>{{ copy().sections.v2233.title }}</ng-container>
     <ng-container description>{{ copy().sections.v2233.description }}</ng-container>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/ui",
-  "version": "22.3.4",
+  "version": "22.3.5",
   "scripts": {
     "build": "bun scripts/build",
     "build:doc": "bun run build:docs",


### PR DESCRIPTION
## Summary
- Sincroniza `DOCS_VERSIONS` com `main` (`v23` + `v22`)
- Endurece o label ativo do header (semver só se o major bater)
- Patch notes / CHANGELOG 22.3.5

## Test plan
- [ ] Em `/v22/`, o seletor mostra `v23` | `22.3.5` (não dois `v22`)
- [ ] Em `/` (após merge da 23), mostra semver 23.x | `v22`


Made with [Cursor](https://cursor.com)